### PR TITLE
Ignore less than a kilo retirements

### DIFF
--- a/contracts/retirement/RetireToucanCarbon.sol
+++ b/contracts/retirement/RetireToucanCarbon.sol
@@ -185,6 +185,10 @@ contract RetireToucanCarbon is
                 address(this)
             );
 
+            // The smallest denomination that can be retired is a kilo,
+            // anything less will fail.
+            if (balance < 1e15) continue;
+
             IToucanCarbonOffsets(listTCO2[i]).retire(balance);
             IKlimaCarbonRetirements(retirementStorage).carbonRetired(
                 _beneficiaryAddress,


### PR DESCRIPTION
Going forward every retirement is going to be
tracked as part of the NFT certificate contract
so it's easy for users to mint a single certificate
with multiple retirements or any combination of
retirements to NFT certificates.

Currently, the smallest denomination in the NFT
certificate is chosen to be a kilogram so any
smaller denomination will be invalid.