### PR TITLE
Add Specific Retirement for Toucan Protocol

### DIFF
--- a/contracts/interfaces/IRetireBridgeCommon.sol
+++ b/contracts/interfaces/IRetireBridgeCommon.sol
@@ -6,7 +6,8 @@ interface IRetireBridgeCommon {
     function getNeededBuyAmount(
         address _sourceToken,
         address _poolToken,
-        uint256 _poolAmount
+        uint256 _poolAmount,
+        bool _retireSpecific
     ) external view returns (uint256, uint256);
 
     function getSwapPath(address _sourceToken, address _poolToken)

--- a/contracts/interfaces/IRetireMossCarbon.sol
+++ b/contracts/interfaces/IRetireMossCarbon.sol
@@ -17,6 +17,7 @@ interface IRetireMossCarbon {
     function getNeededBuyAmount(
         address _sourceToken,
         address _poolToken,
-        uint256 _poolAmount
+        uint256 _poolAmount,
+        bool _retireSpecific
     ) external view returns (uint256, uint256);
 }

--- a/contracts/interfaces/IRetireToucanCarbon.sol
+++ b/contracts/interfaces/IRetireToucanCarbon.sol
@@ -14,9 +14,22 @@ interface IRetireToucanCarbon {
         address _retiree
     ) external;
 
+    function retireToucanSpecific(
+        address _sourceToken,
+        address _poolToken,
+        uint256 _amount,
+        bool _amountInCarbon,
+        address _beneficiaryAddress,
+        string memory _beneficiaryString,
+        string memory _retirementMessage,
+        address _retiree,
+        address[] memory _carbonList
+    ) external;
+
     function getNeededBuyAmount(
         address _sourceToken,
         address _poolToken,
-        uint256 _poolAmount
+        uint256 _poolAmount,
+        bool _retireSpecific
     ) external view returns (uint256, uint256);
 }

--- a/contracts/interfaces/IToucanPool.sol
+++ b/contracts/interfaces/IToucanPool.sol
@@ -3,7 +3,16 @@
 pragma solidity ^0.8.0;
 
 interface IToucanPool {
-    function getScoredTCO2s() external view returns (address[] memory);
+    function redeemAuto2(uint256 amount)
+        external
+        returns (address[] memory tco2s, uint256[] memory amounts);
 
-    function redeemAuto(uint256 amount) external;
+    function redeemMany(address[] calldata erc20s, uint256[] calldata amounts)
+        external;
+
+    function feeRedeemPercentageInBase() external pure returns (uint256);
+
+    function feeRedeemDivider() external pure returns (uint256);
+
+    function redeemFeeExemptedAddresses(address) external view returns (bool);
 }

--- a/contracts/retirement/RetireMossCarbon.sol
+++ b/contracts/retirement/RetireMossCarbon.sol
@@ -238,7 +238,8 @@ contract RetireMossCarbon is
             (sourceAmount, fee) = getNeededBuyAmount(
                 _sourceToken,
                 _poolToken,
-                _amount
+                _amount,
+                false
             );
         } else {
             sourceAmount = _amount;
@@ -320,7 +321,8 @@ contract RetireMossCarbon is
     function getNeededBuyAmount(
         address _sourceToken,
         address _poolToken,
-        uint256 _poolAmount
+        uint256 _poolAmount,
+        bool _specificRetire // @dev Added to maintain consistency between all bridges.
     ) public view returns (uint256, uint256) {
         uint256 fee = (_poolAmount * feeAmount) / 1000;
         uint256 totalAmount = _poolAmount + fee;


### PR DESCRIPTION
Replace `redeemAuto` with `redeemAuto2` to save on gas, as well as implement check
to ensure that the `retire` function is only called on TCO2s actually redeemed. Implements #8 

Add methods to selectively choose and retire TCO2s using the aggregator. This accounts
for any redemption fees incurred so that the desired number of tons will be retired.

Update the `getNeededBuyAmount` function across all helpers to allow consistent switching
between factoring in a redemption fee or just the AMM fees.

