### PR TITLE
Infinity - Add swaps to bridge specific redeem functions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+    "overrides": [
+        {
+            "files": "*.sol",
+            "options": {
+                "printWidth": 120,
+                "tabWidth": 4,
+                "useTabs": false,
+                "singleQuote": false,
+                "bracketSpacing": false,
+                "explicitTypes": "always"
+            }
+        }
+    ]
+}

--- a/abi/KlimaInfinity.json
+++ b/abi/KlimaInfinity.json
@@ -3,12 +3,22 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
                 "name": "poolToken",
                 "type": "address"
             },
             {
                 "internalType": "uint256",
                 "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "maxAmountIn",
                 "type": "uint256"
             },
             {
@@ -22,7 +32,7 @@
                 "type": "uint8"
             }
         ],
-        "name": "c3_redeemPoolDefault",
+        "name": "c3RedeemPoolDefault",
         "outputs": [
             {
                 "internalType": "address[]",
@@ -42,8 +52,18 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
                 "name": "poolToken",
                 "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "maxAmountIn",
+                "type": "uint256"
             },
             {
                 "internalType": "address[]",
@@ -66,7 +86,7 @@
                 "type": "uint8"
             }
         ],
-        "name": "c3_redeemPoolSpecific",
+        "name": "c3RedeemPoolSpecific",
         "outputs": [
             {
                 "internalType": "uint256[]",
@@ -235,12 +255,22 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
                 "name": "poolToken",
                 "type": "address"
             },
             {
                 "internalType": "uint256",
                 "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "maxAmountIn",
                 "type": "uint256"
             },
             {
@@ -254,7 +284,7 @@
                 "type": "uint8"
             }
         ],
-        "name": "toucan_redeemPoolDefault",
+        "name": "toucanRedeemExactCarbonPoolDefault",
         "outputs": [
             {
                 "internalType": "address[]",
@@ -274,8 +304,18 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
                 "name": "poolToken",
                 "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "maxAmountIn",
+                "type": "uint256"
             },
             {
                 "internalType": "address[]",
@@ -298,7 +338,7 @@
                 "type": "uint8"
             }
         ],
-        "name": "toucan_redeemPoolSpecific",
+        "name": "toucanRedeemExactCarbonPoolSpecific",
         "outputs": [
             {
                 "internalType": "uint256[]",

--- a/contracts/infinity/diamond/facets/Bridges/C3/RedeemC3PoolFacet.sol
+++ b/contracts/infinity/diamond/facets/Bridges/C3/RedeemC3PoolFacet.sol
@@ -7,34 +7,58 @@ import "../../../ReentrancyGuard.sol";
 contract RedeemC3PoolFacet is ReentrancyGuard {
     /**
      * @notice                 Redeems default underlying carbon tokens from a C3 Pool
+     * @param sourceToken      Source token to use in the redemption
      * @param poolToken        Pool token to redeem
      * @param amount           Amount to redeem
+     * @param maxAmountIn      Max amount of source token to spend
      * @param fromMode         From Mode for transfering tokens
      * @param toMode           To Mode for where undlerying tokens are sent
      * @return projectTokens   List of underlying tokens received
      * @return amounts         Amounts of underlying tokens received
      */
-    function c3_redeemPoolDefault(
+    function c3RedeemPoolDefault(
+        address sourceToken,
         address poolToken,
         uint256 amount,
+        uint256 maxAmountIn,
         LibTransfer.From fromMode,
         LibTransfer.To toMode
     ) external nonReentrant returns (address[] memory projectTokens, uint256[] memory amounts) {
         require(toMode == LibTransfer.To.EXTERNAL, "Internal balances not live");
-        (projectTokens, amounts) = LibC3Carbon.redeemPoolAuto(poolToken, amount, fromMode, toMode);
+
+        LibTransfer.receiveToken(IERC20(sourceToken), maxAmountIn, msg.sender, fromMode);
+
+        if (sourceToken != poolToken) {
+            if (sourceToken == C.wsKlima()) maxAmountIn = LibKlima.unwrapKlima(maxAmountIn);
+            if (sourceToken == C.sKlima()) LibKlima.unstakeKlima(maxAmountIn);
+
+            uint256 carbonReceived = LibSwap.swapToExactCarbonDefault(sourceToken, poolToken, maxAmountIn, amount);
+
+            require(carbonReceived >= amount, "Swap not enough");
+            amount = carbonReceived;
+
+            // Check for any trade dust and send back
+            LibSwap.returnTradeDust(sourceToken, poolToken);
+        }
+
+        (projectTokens, amounts) = LibC3Carbon.redeemPoolAuto(poolToken, amount, toMode);
     }
 
     /**
      * @notice                     Redeems default underlying carbon tokens from a C3 Pool
+     * @param sourceToken      Source token to use in the redemption
      * @param poolToken            Pool token to redeem
+     * @param maxAmountIn      Max amount of source token to spend
      * @param projectTokens        Underlying tokens to redeem
      * @param amounts              Amounts of underlying tokens to redeem
      * @param fromMode             From Mode for transfering tokens
      * @param toMode               To Mode for where undlerying tokens are sent
      * @return redeemedAmounts     Amounts of underlying tokens redeemed
      */
-    function c3_redeemPoolSpecific(
+    function c3RedeemPoolSpecific(
+        address sourceToken,
         address poolToken,
+        uint256 maxAmountIn,
         address[] memory projectTokens,
         uint256[] memory amounts,
         LibTransfer.From fromMode,
@@ -42,6 +66,27 @@ contract RedeemC3PoolFacet is ReentrancyGuard {
     ) external nonReentrant returns (uint256[] memory redeemedAmounts) {
         require(toMode == LibTransfer.To.EXTERNAL, "Internal balances not live");
         require(projectTokens.length == amounts.length, "Array lengths not equal");
-        redeemedAmounts = LibC3Carbon.redeemPoolSpecific(poolToken, projectTokens, amounts, fromMode, toMode);
+
+        uint256 totalCarbon;
+
+        for (uint256 i; i < amounts.length; i++) {
+            totalCarbon += amounts[i] + LibC3Carbon.getExactCarbonSpecificRedeemFee(poolToken, amounts[i]);
+        }
+
+        uint256 receivedAmount = LibTransfer.receiveToken(IERC20(sourceToken), maxAmountIn, msg.sender, fromMode);
+
+        if (sourceToken != poolToken) {
+            if (sourceToken == C.wsKlima()) maxAmountIn = LibKlima.unwrapKlima(maxAmountIn);
+            if (sourceToken == C.sKlima()) LibKlima.unstakeKlima(maxAmountIn);
+
+            receivedAmount = LibSwap.swapToExactCarbonDefault(sourceToken, poolToken, maxAmountIn, totalCarbon);
+
+            // Check for any trade dust and send back
+            LibSwap.returnTradeDust(sourceToken, poolToken);
+        }
+
+        require(receivedAmount >= totalCarbon, "Not enough pool tokens");
+
+        redeemedAmounts = LibC3Carbon.redeemPoolSpecific(poolToken, projectTokens, amounts, toMode);
     }
 }

--- a/contracts/infinity/diamond/facets/Bridges/Toucan/RedeemToucanPoolFacet.sol
+++ b/contracts/infinity/diamond/facets/Bridges/Toucan/RedeemToucanPoolFacet.sol
@@ -20,7 +20,7 @@ contract RedeemToucanPoolFacet is ReentrancyGuard {
      * @return projectTokens   List of underlying tokens received
      * @return amounts         Amounts of underlying tokens received
      */
-    function toucan_redeemExactCarbonPoolDefault(
+    function toucanRedeemExactCarbonPoolDefault(
         address sourceToken,
         address poolToken,
         uint256 amount,
@@ -59,7 +59,7 @@ contract RedeemToucanPoolFacet is ReentrancyGuard {
      * @param toMode               To Mode for where undlerying tokens are sent
      * @return redeemedAmounts     Amounts of underlying tokens redeemed
      */
-    function toucan_redeemExactCarbonPoolSpecific(
+    function toucanRedeemExactCarbonPoolSpecific(
         address sourceToken,
         address poolToken,
         uint256 maxAmountIn,

--- a/contracts/infinity/diamond/facets/Bridges/Toucan/RedeemToucanPoolFacet.sol
+++ b/contracts/infinity/diamond/facets/Bridges/Toucan/RedeemToucanPoolFacet.sol
@@ -11,34 +11,58 @@ import "../../../ReentrancyGuard.sol";
 contract RedeemToucanPoolFacet is ReentrancyGuard {
     /**
      * @notice                 Redeems default underlying carbon tokens from a Toucan Pool
+     * @param sourceToken      Source token to use in the redemption
      * @param poolToken        Pool token to redeem
      * @param amount           Amount to redeem
+     * @param maxAmountIn      Max amount of source token to spend
      * @param fromMode         From Mode for transfering tokens
      * @param toMode           To Mode for where undlerying tokens are sent
      * @return projectTokens   List of underlying tokens received
      * @return amounts         Amounts of underlying tokens received
      */
-    function toucan_redeemPoolDefault(
+    function toucan_redeemExactCarbonPoolDefault(
+        address sourceToken,
         address poolToken,
         uint256 amount,
+        uint256 maxAmountIn,
         LibTransfer.From fromMode,
         LibTransfer.To toMode
     ) external nonReentrant returns (address[] memory projectTokens, uint256[] memory amounts) {
         require(toMode == LibTransfer.To.EXTERNAL, "Internal balances not live");
-        (projectTokens, amounts) = LibToucanCarbon.redeemPoolAuto(poolToken, amount, fromMode, toMode);
+
+        LibTransfer.receiveToken(IERC20(sourceToken), maxAmountIn, msg.sender, fromMode);
+
+        if (sourceToken != poolToken) {
+            if (sourceToken == C.wsKlima()) maxAmountIn = LibKlima.unwrapKlima(maxAmountIn);
+            if (sourceToken == C.sKlima()) LibKlima.unstakeKlima(maxAmountIn);
+
+            uint256 carbonReceived = LibSwap.swapToExactCarbonDefault(sourceToken, poolToken, maxAmountIn, amount);
+
+            require(carbonReceived >= amount, "Swap not enough");
+            amount = carbonReceived;
+
+            // Check for any trade dust and send back
+            LibSwap.returnTradeDust(sourceToken, poolToken);
+        }
+
+        (projectTokens, amounts) = LibToucanCarbon.redeemPoolAuto(poolToken, amount, toMode);
     }
 
     /**
-     * @notice                     Redeems default underlying carbon tokens from a Toucan Pool
+     * @notice                     Redeems specific underlying carbon tokens from a Toucan Pool
+     * @param sourceToken          Source token to use in the redemption
      * @param poolToken            Pool token to redeem
+     * @param maxAmountIn          Maximum amount of source token to spend
      * @param projectTokens        Underlying tokens to redeem
      * @param amounts              Amounts of underlying tokens to redeem
      * @param fromMode             From Mode for transfering tokens
      * @param toMode               To Mode for where undlerying tokens are sent
      * @return redeemedAmounts     Amounts of underlying tokens redeemed
      */
-    function toucan_redeemPoolSpecific(
+    function toucan_redeemExactCarbonPoolSpecific(
+        address sourceToken,
         address poolToken,
+        uint256 maxAmountIn,
         address[] memory projectTokens,
         uint256[] memory amounts,
         LibTransfer.From fromMode,
@@ -46,6 +70,28 @@ contract RedeemToucanPoolFacet is ReentrancyGuard {
     ) external nonReentrant returns (uint256[] memory redeemedAmounts) {
         require(toMode == LibTransfer.To.EXTERNAL, "Internal balances not live");
         require(projectTokens.length == amounts.length, "Array lengths not equal");
-        redeemedAmounts = LibToucanCarbon.redeemPoolSpecific(poolToken, projectTokens, amounts, fromMode, toMode);
+
+        uint256 totalCarbon;
+
+        for (uint256 i; i < amounts.length; i++) {
+            amounts[i] += LibToucanCarbon.getSpecificRedeemFee(poolToken, amounts[i]);
+            totalCarbon += amounts[i];
+        }
+
+        uint256 receivedAmount = LibTransfer.receiveToken(IERC20(sourceToken), maxAmountIn, msg.sender, fromMode);
+
+        if (sourceToken != poolToken) {
+            if (sourceToken == C.wsKlima()) maxAmountIn = LibKlima.unwrapKlima(maxAmountIn);
+            if (sourceToken == C.sKlima()) LibKlima.unstakeKlima(maxAmountIn);
+
+            receivedAmount = LibSwap.swapToExactCarbonDefault(sourceToken, poolToken, maxAmountIn, totalCarbon);
+
+            // Check for any trade dust and send back
+            LibSwap.returnTradeDust(sourceToken, poolToken);
+        }
+
+        require(receivedAmount >= totalCarbon, "Not enough pool tokens");
+
+        redeemedAmounts = LibToucanCarbon.redeemPoolSpecific(poolToken, projectTokens, amounts, toMode);
     }
 }

--- a/contracts/infinity/diamond/facets/RetirementQuoter.sol
+++ b/contracts/infinity/diamond/facets/RetirementQuoter.sol
@@ -39,4 +39,25 @@ contract RetirementQuoter {
         if (sourceToken == carbonToken) return totalCarbon;
         return LibSwap.getSourceAmount(sourceToken, carbonToken, totalCarbon);
     }
+
+    function getSourceAmountDefaultRedeem(
+        address sourceToken,
+        address carbonToken,
+        uint256 redeemAmount
+    ) public view returns (uint256 amountIn) {
+        if (sourceToken == carbonToken) return redeemAmount;
+        return LibSwap.getSourceAmount(sourceToken, carbonToken, redeemAmount);
+    }
+
+    function getSourceAmountSpecificRedeem(
+        address sourceToken,
+        address carbonToken,
+        uint256[] memory redeemAmounts
+    ) public view returns (uint256 amountIn) {
+        for (uint256 i; i < redeemAmounts.length; i++) {
+            redeemAmounts[i] += LibToucanCarbon.getSpecificRedeemFee(carbonToken, redeemAmounts[i]);
+            amountIn += redeemAmounts[i];
+        }
+        if (sourceToken != carbonToken) return LibSwap.getSourceAmount(sourceToken, carbonToken, amountIn);
+    }
 }

--- a/contracts/infinity/libraries/Bridges/LibToucanCarbon.sol
+++ b/contracts/infinity/libraries/Bridges/LibToucanCarbon.sol
@@ -207,7 +207,6 @@ library LibToucanCarbon {
      * @notice                      Simple wrapper to use redeem Toucan pools using the default list
      * @param poolToken             Pool token to redeem
      * @param amount                Amount of tokens being redeemed
-     * @param fromMode              Where to receive pool tokens
      * @param toMode                Where to send TCO2 tokens
      * @return projectTokens        TCO2 token addresses redeemed
      * @return amounts              TCO2 token amounts redeemed
@@ -215,10 +214,8 @@ library LibToucanCarbon {
     function redeemPoolAuto(
         address poolToken,
         uint256 amount,
-        LibTransfer.From fromMode,
         LibTransfer.To toMode
     ) internal returns (address[] memory projectTokens, uint256[] memory amounts) {
-        LibTransfer.receiveToken(IERC20(poolToken), amount, msg.sender, fromMode);
         (projectTokens, amounts) = IToucanPool(poolToken).redeemAuto2(amount);
         for (uint256 i; i < projectTokens.length; i++) {
             LibTransfer.sendToken(IERC20(projectTokens[i]), amounts[i], msg.sender, toMode);
@@ -230,7 +227,6 @@ library LibToucanCarbon {
      * @param poolToken             Pool token to redeem
      * @param projectTokens         Project tokens to redeem
      * @param amounts               Token amounts to redeem
-     * @param fromMode              Where to receive pool tokens
      * @param toMode                Where to send TCO2 tokens
      * @return redeemedAmounts      TCO2 token amounts redeemed
      */
@@ -238,18 +234,11 @@ library LibToucanCarbon {
         address poolToken,
         address[] memory projectTokens,
         uint256[] memory amounts,
-        LibTransfer.From fromMode,
         LibTransfer.To toMode
     ) internal returns (uint256[] memory) {
-        uint256 sum;
         uint256[] memory beforeBalances = new uint256[](projectTokens.length);
         uint256[] memory redeemedAmounts = new uint256[](projectTokens.length);
-        for (uint256 i; i < projectTokens.length; i++) {
-            beforeBalances[i] = IERC20(projectTokens[i]).balanceOf(address(this));
-            sum = sum + amounts[i];
-        }
 
-        LibTransfer.receiveToken(IERC20(poolToken), sum, msg.sender, fromMode);
         IToucanPool(poolToken).redeemMany(projectTokens, amounts);
 
         for (uint256 i; i < projectTokens.length; i++) {

--- a/test/C3Redeem.test.js
+++ b/test/C3Redeem.test.js
@@ -8,7 +8,7 @@ const { deployDiamond } = require('../scripts/deploy.js')
 
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
-const { UBO, NBO, KLIMA_CARBON_RETIREMENTS } = require('./utils/constants.js');
+const { UBO, NBO, KLIMA_CARBON_RETIREMENTS, USDC, KLIMA, SKLIMA, WSKLIMA } = require('./utils/constants.js');
 
 describe('C3 Redeem Functions', async function () {
 
@@ -16,14 +16,23 @@ describe('C3 Redeem Functions', async function () {
         diamond = await deployDiamond()
         redeemFacet = await ethers.getContractAt('RedeemC3PoolFacet', diamond)
         retireInfoFacet = await ethers.getContractAt('RetireInfoFacet', diamond)
+        quoter = await ethers.getContractAt('RetirementQuoter', diamond)
 
         // Approve token spend for diamond.
         console.log('----Approving Tokens for Spending----')
         abi = ["function approve(address spender, uint256 amount)", "function balanceOf(address) view returns(uint256)"]
         signer = await ethers.getSigner()
+        usdc = await ethers.getContractAt(abi, USDC, signer)
+        klima = await ethers.getContractAt(abi, KLIMA, signer)
+        sklima = await ethers.getContractAt(abi, SKLIMA, signer)
+        wsklima = await ethers.getContractAt(abi, WSKLIMA, signer)
         ubo = await ethers.getContractAt(abi, UBO, signer)
         nbo = await ethers.getContractAt(abi, NBO, signer)
 
+        await usdc.approve(diamond, '1000000000000000000000000')
+        await klima.approve(diamond, '1000000000000000000000000')
+        await sklima.approve(diamond, '1000000000000000000000000')
+        await wsklima.approve(diamond, '1000000000000000000000000')
         await ubo.approve(diamond, '1000000000000000000000000')
         await nbo.approve(diamond, '1000000000000000000000000')
 
@@ -51,85 +60,535 @@ describe('C3 Redeem Functions', async function () {
 
     describe('External Default Redemptions', async function () {
         describe('Redeem UBO', async () => {
-            beforeEach(async () => {
-                this.result = await redeemFacet.c3_redeemPoolDefault(UBO,
-                    defaultCarbonRetireAmount,
-                    EXTERNAL,
-                    EXTERNAL)
+            describe('Using UBO', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(UBO, UBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        UBO,
+                        UBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await ubo.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await tco2.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('No tokens left in contract', async () => {
-                tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
-                expect(await ubo.balanceOf(redeemFacet.address)).equals(0)
-                expect(await tco2.balanceOf(redeemFacet.address)).equals(0)
+            describe('Using USDC', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(USDC, UBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        USDC,
+                        UBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await usdc.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await tco2.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('Account state values updated', async () => {
-                expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
-                expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+            describe('Using KLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(KLIMA, UBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        KLIMA,
+                        UBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await tco2.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('Caller has TCO2 tokens', async () => {
-                tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
-                expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+            describe('Using sKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(SKLIMA, UBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        SKLIMA,
+                        UBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await tco2.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
+            })
+            describe('Using wsKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(WSKLIMA, UBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        WSKLIMA,
+                        UBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await wsklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await tco2.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
         })
         describe('Redeem NBO', async () => {
-            beforeEach(async () => {
-                this.result = await redeemFacet.c3_redeemPoolDefault(NBO,
-                    defaultCarbonRetireAmount,
-                    EXTERNAL,
-                    EXTERNAL)
+            describe('Using NBO', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(NBO, NBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        NBO,
+                        NBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await nbo.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('No tokens left in contract', async () => {
-                expect(await nbo.balanceOf(redeemFacet.address)).equals(0)
+            describe('Using USDC', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(USDC, NBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        USDC,
+                        NBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await usdc.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('Account state values updated', async () => {
-                expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
-                expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+            describe('Using KLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(KLIMA, NBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        KLIMA,
+                        NBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('Caller has TCO2 tokens', async () => {
-                tco2 = await ethers.getContractAt(abi, nboDefaultProjectAddress, signer)
-                expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+            describe('Using sKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(SKLIMA, NBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        SKLIMA,
+                        NBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
+            })
+            describe('Using wsKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(WSKLIMA, NBO, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.c3RedeemPoolDefault(
+                        WSKLIMA,
+                        NBO,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await wsklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
         })
     })
     describe('External Specific Redemptions', async function () {
         describe('Redeem UBO', async () => {
-            beforeEach(async () => {
-                this.result = await redeemFacet.c3_redeemPoolSpecific(UBO,
-                    [uboSpecificProjectAddress],
-                    [ethers.BigNumber.from(defaultCarbonRetireAmount)],
-                    EXTERNAL,
-                    EXTERNAL)
+            describe('Using UBO', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(UBO, UBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        UBO,
+                        UBO,
+                        sourceAmount,
+                        [uboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await ubo.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('No tokens left in contract', async () => {
-                expect(await ubo.balanceOf(redeemFacet.address)).equals(0)
+            describe('Using USDC', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(USDC, UBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        USDC,
+                        UBO,
+                        sourceAmount,
+                        [uboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await usdc.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('Account state values updated', async () => {
-                expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
-                expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+            describe('Using KLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(KLIMA, UBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        KLIMA,
+                        UBO,
+                        sourceAmount,
+                        [uboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('Caller has TCO2 tokens', async () => {
-                tco2 = await ethers.getContractAt(abi, uboSpecificProjectAddress, signer)
-                expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+            describe('Using sKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(SKLIMA, UBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        SKLIMA,
+                        UBO,
+                        sourceAmount,
+                        [uboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
+            })
+            describe('Using wsKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(WSKLIMA, UBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        WSKLIMA,
+                        UBO,
+                        sourceAmount,
+                        [uboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await wsklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, uboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
         })
         describe('Redeem NBO', async () => {
-            beforeEach(async () => {
-                this.result = await redeemFacet.c3_redeemPoolSpecific(NBO,
-                    [nboSpecificProjectAddress],
-                    [ethers.BigNumber.from(defaultCarbonRetireAmount)],
-                    EXTERNAL,
-                    EXTERNAL)
+            describe('Using NBO', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(NBO, NBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        NBO,
+                        NBO,
+                        sourceAmount,
+                        [nboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await nbo.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('No tokens left in contract', async () => {
-                expect(await nbo.balanceOf(redeemFacet.address)).equals(0)
+            describe('Using USDC', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(USDC, NBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        USDC,
+                        NBO,
+                        sourceAmount,
+                        [nboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await usdc.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('Account state values updated', async () => {
-                expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
-                expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+            describe('Using KLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(KLIMA, NBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        KLIMA,
+                        NBO,
+                        sourceAmount,
+                        [nboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
-            it('Caller has TCO2 tokens', async () => {
-                tco2 = await ethers.getContractAt(abi, nboSpecificProjectAddress, signer)
-                expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+            describe('Using sKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(SKLIMA, NBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        SKLIMA,
+                        NBO,
+                        sourceAmount,
+                        [nboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
+            })
+            describe('Using wsKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(WSKLIMA, NBO, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.c3RedeemPoolSpecific(
+                        WSKLIMA,
+                        NBO,
+                        sourceAmount,
+                        [nboSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await wsklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nboSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).greaterThanOrEqual(defaultCarbonRetireAmount)
+                })
             })
         })
     })

--- a/test/ToucanRedeem.test.js
+++ b/test/ToucanRedeem.test.js
@@ -8,7 +8,7 @@ const { deployDiamond } = require('../scripts/deploy.js')
 
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
-const { BCT, NCT, KLIMA_CARBON_RETIREMENTS } = require('./utils/constants.js');
+const { BCT, NCT, KLIMA_CARBON_RETIREMENTS, USDC, KLIMA, SKLIMA, WSKLIMA } = require('./utils/constants.js');
 
 describe('Toucan Redeem Functions', async function () {
 
@@ -16,21 +16,30 @@ describe('Toucan Redeem Functions', async function () {
         diamond = await deployDiamond()
         redeemFacet = await ethers.getContractAt('RedeemToucanPoolFacet', diamond)
         retireInfoFacet = await ethers.getContractAt('RetireInfoFacet', diamond)
+        quoter = await ethers.getContractAt('RetirementQuoter', diamond)
 
         // Approve token spend for diamond.
         console.log('----Approving Tokens for Spending----')
         abi = ["function approve(address spender, uint256 amount)", "function balanceOf(address) view returns(uint256)"]
         signer = await ethers.getSigner()
+        usdc = await ethers.getContractAt(abi, USDC, signer)
+        klima = await ethers.getContractAt(abi, KLIMA, signer)
+        sklima = await ethers.getContractAt(abi, SKLIMA, signer)
+        wsklima = await ethers.getContractAt(abi, WSKLIMA, signer)
         bct = await ethers.getContractAt(abi, BCT, signer)
         nct = await ethers.getContractAt(abi, NCT, signer)
 
+        await usdc.approve(diamond, '1000000000000000000000000')
+        await klima.approve(diamond, '1000000000000000000000000')
+        await sklima.approve(diamond, '1000000000000000000000000')
+        await wsklima.approve(diamond, '1000000000000000000000000')
         await bct.approve(diamond, '1000000000000000000000000')
         await nct.approve(diamond, '1000000000000000000000000')
 
         userAddress = signer.address
         defaultCarbonRetireAmount = '100000000000'
         bctDefaultProjectAddress = '0xb139C4cC9D20A3618E9a2268D73Eff18C496B991'
-        nctDefaultProjectAddress = '0x463de2a5c6E8Bb0c87F4Aa80a02689e6680F72C7'
+        nctDefaultProjectAddress = '0x6362364A37F34d39a1f4993fb595dAB4116dAf0d'
         bctSpecificProjectAddress = '0x35B73A62Dd351030eCBd4252135e59bbb6345a60'
         nctSpecificProjectAddress = '0x04943C19896c776c78770429eC02C5384ee78292'
 
@@ -52,83 +61,536 @@ describe('Toucan Redeem Functions', async function () {
 
     describe('External Default Redemptions', async function () {
         describe('Redeem BCT', async () => {
-            beforeEach(async () => {
-                this.result = await redeemFacet.toucan_redeemPoolDefault(BCT,
-                    defaultCarbonRetireAmount,
-                    EXTERNAL,
-                    EXTERNAL)
+            describe('Using BCT', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(BCT, BCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        BCT,
+                        BCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('No tokens left in contract', async () => {
-                expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+            describe('Using USDC', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(USDC, BCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        USDC,
+                        BCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await usdc.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('Account state values updated', async () => {
-                expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
-                expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+            describe('Using KLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(KLIMA, BCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        KLIMA,
+                        BCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('Caller has TCO2 tokens', async () => {
-                tco2 = await ethers.getContractAt(abi, bctDefaultProjectAddress, signer)
-                expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+            describe('Using sKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(SKLIMA, BCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        SKLIMA,
+                        BCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
+            })
+            describe('Using wsKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(WSKLIMA, BCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        WSKLIMA,
+                        BCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await wsklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
         })
         describe('Redeem NCT', async () => {
-            beforeEach(async () => {
-                this.result = await redeemFacet.toucan_redeemPoolDefault(NCT,
-                    defaultCarbonRetireAmount,
-                    EXTERNAL,
-                    EXTERNAL)
+            describe('Using NCT ', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(NCT, NCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        NCT,
+                        NCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('No tokens left in contract', async () => {
-                expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+            describe('Using USDC ', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(USDC, NCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        USDC,
+                        NCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await usdc.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('Account state values updated', async () => {
-                expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
-                expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+            describe('Using KLIMA ', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(KLIMA, NCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        KLIMA,
+                        NCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('Caller has TCO2 tokens', async () => {
-                tco2 = await ethers.getContractAt(abi, nctDefaultProjectAddress, signer)
-                expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+            describe('Using sKLIMA ', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(SKLIMA, NCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        SKLIMA,
+                        NCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
+            })
+            describe('Using wsKLIMA ', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountDefaultRedeem(WSKLIMA, NCT, defaultCarbonRetireAmount)
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolDefault(
+                        WSKLIMA,
+                        NCT,
+                        defaultCarbonRetireAmount,
+                        sourceAmount,
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await wsklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctDefaultProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
         })
     })
     describe('External Specific Redemptions', async function () {
         describe('Redeem BCT', async () => {
-            beforeEach(async () => {
-                this.result = await redeemFacet.toucan_redeemPoolSpecific(BCT,
-                    [bctSpecificProjectAddress],
-                    [ethers.BigNumber.from(defaultCarbonRetireAmount)],
-                    EXTERNAL,
-                    EXTERNAL)
+            describe('Using BCT', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(BCT, BCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        BCT,
+                        BCT,
+                        sourceAmount,
+                        [bctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('No tokens left in contract', async () => {
-                expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+            describe('Using USDC', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(USDC, BCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        USDC,
+                        BCT,
+                        sourceAmount,
+                        [bctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await usdc.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('Account state values updated', async () => {
-                expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
-                expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+            describe('Using KLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(KLIMA, BCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        KLIMA,
+                        BCT,
+                        sourceAmount,
+                        [bctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('Caller has TCO2 tokens', async () => {
-                tco2 = await ethers.getContractAt(abi, bctSpecificProjectAddress, signer)
-                expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount * .75)
+            describe('Using sKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(SKLIMA, BCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        SKLIMA,
+                        BCT,
+                        sourceAmount,
+                        [bctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
+            })
+            describe('Using wsKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(WSKLIMA, BCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        WSKLIMA,
+                        BCT,
+                        sourceAmount,
+                        [bctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL
+                    )
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await wsklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await bct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, bctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
         })
         describe('Redeem NCT', async () => {
-            beforeEach(async () => {
-                this.result = await redeemFacet.toucan_redeemPoolSpecific(NCT,
-                    [nctSpecificProjectAddress],
-                    [ethers.BigNumber.from(defaultCarbonRetireAmount)],
-                    EXTERNAL,
-                    EXTERNAL)
+            describe('Using NCT', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(NCT, NCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        NCT,
+                        NCT,
+                        sourceAmount,
+                        [nctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('No tokens left in contract', async () => {
-                expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+            describe('Using USDC', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(USDC, NCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        USDC,
+                        NCT,
+                        sourceAmount,
+                        [nctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await usdc.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('Account state values updated', async () => {
-                expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
-                expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+            describe('Using KLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(KLIMA, NCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        KLIMA,
+                        NCT,
+                        sourceAmount,
+                        [nctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
-            it('Caller has TCO2 tokens', async () => {
-                tco2 = await ethers.getContractAt(abi, nctSpecificProjectAddress, signer)
-                expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount * .9)
+            describe('Using sKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(SKLIMA, NCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        SKLIMA,
+                        NCT,
+                        sourceAmount,
+                        [nctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
+            })
+            describe('Using wsKLIMA', async () => {
+                beforeEach(async () => {
+                    sourceAmount = await quoter.getSourceAmountSpecificRedeem(WSKLIMA, NCT, [ethers.BigNumber.from(defaultCarbonRetireAmount)])
+
+                    this.result = await redeemFacet.toucan_redeemExactCarbonPoolSpecific(
+                        WSKLIMA,
+                        NCT,
+                        sourceAmount,
+                        [nctSpecificProjectAddress],
+                        [ethers.BigNumber.from(defaultCarbonRetireAmount)],
+                        EXTERNAL,
+                        EXTERNAL)
+                })
+                it('No tokens left in contract', async () => {
+                    expect(await wsklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await sklima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await klima.balanceOf(redeemFacet.address)).equals(0)
+                    expect(await nct.balanceOf(redeemFacet.address)).equals(0)
+                })
+                it('Account state values updated', async () => {
+                    expect(await retireInfoFacet.getTotalRetirements(userAddress)).equals(currentRetirements)
+                    expect(await retireInfoFacet.getTotalCarbonRetired(userAddress)).equals(currentTotalCarbon)
+                })
+                it('Caller has TCO2 tokens', async () => {
+                    tco2 = await ethers.getContractAt(abi, nctSpecificProjectAddress, signer)
+                    expect(await tco2.balanceOf(signer.address)).equals(defaultCarbonRetireAmount)
+                })
             })
         })
     })


### PR DESCRIPTION
Instead of making the assumption that a caller has previously obtained a pool token and hold it in their wallet, allow similar routing across default paths to occur if the desired result is to redeem project tokens.