### PR TITLE
1st Pass - minor code review updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "forge t -vvv --ffi --fork-url http://localhost:8545",
     "test-infinity": "forge t -vvv --ffi --fork-url http://localhost:8545 -m test_infinity",
     "test-protocol": "forge t -vvv --ffi --fork-url http://localhost:8545 -m test_protocol",
-    "fork": "eval $(grep '^POLYGON_URL' .env) && anvil --fork-url ${POLYGON_URL} --block-base-fee-per-gas 30000000000"
+    "fork": "eval $(grep '^POLYGON_URL' .env) && anvil --fork-url ${POLYGON_URL} --block-base-fee-per-gas 30000000000",
+    "deploy-local-RB": "forge script script/deployRetirementBond.s.sol --fork-url http://localhost:8545 --broadcast --ffi"
   },
   "repository": {
     "type": "git",

--- a/src/protocol/allocators/RetirementBondAllocator.sol
+++ b/src/protocol/allocators/RetirementBondAllocator.sol
@@ -47,7 +47,7 @@ contract RetirementBondAllocator is Ownable2Step {
      * @param token The address of the token to fund the retirement bonds with.
      * @param amount The amount of tokens to fund the retirement bonds with.
      */
-    function fundBonds(address token, uint256 amount) external onlyDAO {
+    function fundBonds(address token, uint256 amount) external onlyOwner {
         // Limit the maximium amount of reserves that can be pulled from the treasury to the lower of the
         // excess reserves or tokens held by the treasury
 
@@ -69,7 +69,7 @@ contract RetirementBondAllocator is Ownable2Step {
      * @dev Closes the retirement bonds market for a specified token, transferring any remaining tokens to the treasury.
      * @param token The address of the token for which to close the retirement bonds market.
      */
-    function closeBonds(address token) external onlyDAO {
+    function closeBonds(address token) external onlyOwner {
         IKlimaRetirementBond(bondContract).closeMarket(token);
 
         // Extra gas and transfers no tokens, but does trigger a reserve update within the treasury.
@@ -80,7 +80,7 @@ contract RetirementBondAllocator is Ownable2Step {
      * @notice Updates the retirement bond contract being used.
      * @param _bondContract The address of the new retirement bond contract.
      */
-    function updateBondContract(address _bondContract) external onlyDAO {
+    function updateBondContract(address _bondContract) external onlyOwner {
         bondContract = _bondContract;
     }
 

--- a/src/protocol/bonds/CarbonRetirementBondDepository.sol
+++ b/src/protocol/bonds/CarbonRetirementBondDepository.sol
@@ -55,14 +55,6 @@ contract CarbonRetirementBondDepository is Ownable2Step {
     event KlimaBonded(uint256 daoFee, uint256 klimaBurned);
 
     /**
-     * @notice Modifier to ensure that the caller is the DAO multi-sig.
-     */
-    modifier onlyDAO() {
-        require(msg.sender == DAO, "Caller must be DAO");
-        _;
-    }
-
-    /**
      * @notice Modifier to ensure that the calling function is being called by the allocator contract.
      */
     modifier onlyAllocator() {
@@ -82,7 +74,7 @@ contract CarbonRetirementBondDepository is Ownable2Step {
 
         uint256 klimaNeeded = getKlimaAmount(poolAmount, poolToken);
 
-        transferAndBurnKlima(klimaNeeded, poolToken);
+        _transferAndBurnKlima(klimaNeeded, poolToken);
         IKlima(poolToken).safeTransfer(INFINITY, poolAmount);
 
         emit CarbonBonded(poolToken, poolAmount);
@@ -122,7 +114,7 @@ contract CarbonRetirementBondDepository is Ownable2Step {
         uint256 klimaNeeded = getKlimaAmount(poolNeeded, poolToken);
 
         // Transfer and burn the KLIMA
-        transferAndBurnKlima(klimaNeeded, poolToken);
+        _transferAndBurnKlima(klimaNeeded, poolToken);
 
         IKlima(poolToken).safeIncreaseAllowance(INFINITY, poolNeeded);
 
@@ -179,7 +171,7 @@ contract CarbonRetirementBondDepository is Ownable2Step {
         uint256 klimaNeeded = getKlimaAmount(poolNeeded, poolToken);
 
         // Transfer and burn the KLIMA
-        transferAndBurnKlima(klimaNeeded, poolToken);
+        _transferAndBurnKlima(klimaNeeded, poolToken);
 
         IKlima(poolToken).safeIncreaseAllowance(INFINITY, poolNeeded);
 
@@ -238,7 +230,7 @@ contract CarbonRetirementBondDepository is Ownable2Step {
      * @param poolToken The address of the pool token to update the DAO fee for.
      * @param _daoFee The new DAO fee.
      */
-    function updateDaoFee(address poolToken, uint256 _daoFee) external onlyDAO {
+    function updateDaoFee(address poolToken, uint256 _daoFee) external onlyOwner {
         uint256 oldFee = daoFee[poolToken];
         daoFee[poolToken] = _daoFee;
 
@@ -266,7 +258,7 @@ contract CarbonRetirementBondDepository is Ownable2Step {
      * @notice Sets the address of the allocator contract. Only the contract owner can call this function.
      * @param allocator The address of the allocator contract to set.
      */
-    function setAllocator(address allocator) external onlyDAO {
+    function setAllocator(address allocator) external onlyOwner {
         address oldAllocator = allocatorContract;
         allocatorContract = allocator;
 
@@ -304,7 +296,7 @@ contract CarbonRetirementBondDepository is Ownable2Step {
      * @param totalKlima    The total amount of KLIMA tokens to transfer and burn.
      * @param poolToken     The address of the pool token to burn KLIMA tokens for.
      */
-    function transferAndBurnKlima(uint256 totalKlima, address poolToken) private {
+    function _transferAndBurnKlima(uint256 totalKlima, address poolToken) private {
         // Transfer and burn the KLIMA
         uint256 feeAmount = (totalKlima * daoFee[poolToken]) / FEE_DIVISOR;
 


### PR DESCRIPTION
1. The transferAndBurnKlima function in CarbonRetirementBondDepository had an *internal* function visibility, but should really be *private* since *internal* functions can be called from any contract that decides to inherit from CarbonRetirementBondDepository. For example, anyone can mess with the total in emitted "KlimaBonded" events, which might break some integration further down the pipeline.

2. Change ensureOnlyDao function to modifier. Same with onlyAllocator.

3. Changed private function name for better readability.

4. Minor typo.

5. Call safeTransfer() instead of transfer().

6. Add yarn deployment script.
