### PR TITLE
Update Quoter to use Retirement Bonds

### DIFF
--- a/script/upgradeInfinity.s.sol
+++ b/script/upgradeInfinity.s.sol
@@ -39,12 +39,11 @@ contract DeployInfinityScript is Script, HelperContract {
         RedeemToucanPoolFacet toucanRedeemF = new RedeemToucanPoolFacet();
         RetireToucanTCO2Facet toucanRetireF = new RetireToucanTCO2Facet();
         RetireCarbonFacet retireCarbonF = new RetireCarbonFacet();
-        RetireInfoFacet retireInfoF = new RetireInfoFacet();
         RetireSourceFacet retireSourceF = new RetireSourceFacet();
         RetirementQuoter retirementQuoterF = new RetirementQuoter();
 
         // FacetCut array which contains the three standard facets to be added
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](9);
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](7);
 
         // Klima Infinity specific facets
 
@@ -90,43 +89,17 @@ contract DeployInfinityScript is Script, HelperContract {
 
         cut[5] = (
             IDiamondCut.FacetCut({
-                facetAddress: address(retireInfoF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireInfoFacet")
-            })
-        );
-
-        cut[6] = (
-            IDiamondCut.FacetCut({
                 facetAddress: address(retireSourceF),
                 action: IDiamondCut.FacetCutAction.Replace,
                 functionSelectors: generateSelectors("RetireSourceFacet")
             })
         );
 
-        bytes4[] memory currentSelectors = new bytes4[](5);
-        currentSelectors[0] = bytes4(0xf8262473);
-        currentSelectors[1] = bytes4(0xf0ff264c);
-        currentSelectors[2] = bytes4(0x16950775);
-        currentSelectors[3] = bytes4(0x79f5e053);
-        currentSelectors[4] = bytes4(0x7eed24a2);
-        bytes4[] memory newSelectors = new bytes4[](2);
-        newSelectors[0] = bytes4(0x8298360e);
-        newSelectors[1] = bytes4(0x58bdb8e8);
-
-        cut[7] = (
+        cut[6] = (
             IDiamondCut.FacetCut({
                 facetAddress: address(retirementQuoterF),
                 action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: currentSelectors
-            })
-        );
-
-        cut[8] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(retirementQuoterF),
-                action: IDiamondCut.FacetCutAction.Add,
-                functionSelectors: newSelectors
+                functionSelectors: generateSelectors("RetirementQuoter")
             })
         );
 

--- a/src/infinity/facets/Retire/RetireCarbonFacet.sol
+++ b/src/infinity/facets/Retire/RetireCarbonFacet.sol
@@ -59,8 +59,11 @@ contract RetireCarbonFacet is ReentrancyGuard {
                 maxAmountIn = LibKlima.unwrapKlima(maxAmountIn);
             }
             if (sourceToken == C.sKlima()) LibKlima.unstakeKlima(maxAmountIn);
-
-            uint carbonReceived = LibSwap.swapToExactCarbonDefault(sourceToken, poolToken, maxAmountIn, totalCarbon);
+            
+            uint256 carbonReceived;
+            if (IERC20(poolToken).balanceOf(C.klimaRetirementBond()) >= totalCarbon)
+                carbonReceived = LibSwap.swapWithRetirementBonds(sourceToken, poolToken, maxAmountIn, totalCarbon);
+            else carbonReceived = LibSwap.swapToExactCarbonDefault(sourceToken, poolToken, maxAmountIn, totalCarbon);
 
             require(carbonReceived >= totalCarbon, "Swap not enough");
             totalCarbon = carbonReceived;
@@ -131,7 +134,10 @@ contract RetireCarbonFacet is ReentrancyGuard {
             }
             if (sourceToken == C.sKlima()) LibKlima.unstakeKlima(maxAmountIn);
 
-            uint carbonReceived = LibSwap.swapToExactCarbonDefault(sourceToken, poolToken, maxAmountIn, totalCarbon);
+            uint256 carbonReceived;
+            if (IERC20(poolToken).balanceOf(C.klimaRetirementBond()) >= totalCarbon)
+                carbonReceived = LibSwap.swapWithRetirementBonds(sourceToken, poolToken, maxAmountIn, totalCarbon);
+            else carbonReceived = LibSwap.swapToExactCarbonDefault(sourceToken, poolToken, maxAmountIn, totalCarbon);
 
             // Check for any trade dust and send back
             LibSwap.returnTradeDust(sourceToken, poolToken);

--- a/src/infinity/facets/RetirementQuoter.sol
+++ b/src/infinity/facets/RetirementQuoter.sol
@@ -29,7 +29,12 @@ contract RetirementQuoter {
         uint retireAmount
     ) public view returns (uint amountIn) {
         uint totalCarbon = LibRetire.getTotalCarbon(retireAmount);
+
         if (sourceToken == carbonToken) return totalCarbon;
+
+        if (IERC20(carbonToken).balanceOf(C.klimaRetirementBond()) >= totalCarbon)
+            return LibSwap.getSourceAmountFromRetirementBond(sourceToken, carbonToken, totalCarbon);
+
         return LibSwap.getSourceAmount(sourceToken, carbonToken, totalCarbon);
     }
 
@@ -39,7 +44,12 @@ contract RetirementQuoter {
         uint retireAmount
     ) public view returns (uint amountIn) {
         uint totalCarbon = LibRetire.getTotalCarbonSpecific(carbonToken, retireAmount);
+
         if (sourceToken == carbonToken) return totalCarbon;
+
+        if (IERC20(carbonToken).balanceOf(C.klimaRetirementBond()) >= totalCarbon)
+            return LibSwap.getSourceAmountFromRetirementBond(sourceToken, carbonToken, totalCarbon);
+
         return LibSwap.getSourceAmount(sourceToken, carbonToken, totalCarbon);
     }
 
@@ -49,6 +59,7 @@ contract RetirementQuoter {
         uint redeemAmount
     ) public view returns (uint amountIn) {
         if (sourceToken == carbonToken) return redeemAmount;
+        
         return LibSwap.getSourceAmount(sourceToken, carbonToken, redeemAmount);
     }
 

--- a/src/infinity/libraries/TokenSwap/LibSwap.sol
+++ b/src/infinity/libraries/TokenSwap/LibSwap.sol
@@ -38,10 +38,6 @@ library LibSwap {
         // If providing a staked version of Klima, update sourceToken to use Klima default path.
         if (sourceToken == C.sKlima() || sourceToken == C.wsKlima()) sourceToken = C.klima();
 
-        // Check RB balance and use if possible
-        if (IERC20(carbonToken).balanceOf(C.klimaRetirementBond()) >= carbonAmount)
-            return swapWithRetirementBonds(sourceToken, carbonToken, sourceAmount, carbonAmount);
-
         // If source token is not defined in the default, swap to USDC on Sushiswap.
         // This is wrapped in its own statement to allow for the fewest number of swaps
         if (s.swap[carbonToken][sourceToken].swapDexes.length == 0) {

--- a/src/infinity/libraries/TokenSwap/LibSwap.sol
+++ b/src/infinity/libraries/TokenSwap/LibSwap.sol
@@ -217,7 +217,8 @@ library LibSwap {
         uint256 sourceAmount,
         uint256 carbonAmount
     ) internal returns (uint256 carbonRecieved) {
-        if (sourceToken == C.klima()) {
+        // Any form of KLIMA should be unwrapped/unstaked before this is called.
+        if (sourceToken == C.klima() || sourceToken == C.sKlima() || sourceToken == C.wsKlima()) {
             LibTreasurySwap.swapToExact(carbonToken, sourceAmount, carbonAmount);
             return carbonAmount;
         }

--- a/src/infinity/libraries/TokenSwap/LibSwap.sol
+++ b/src/infinity/libraries/TokenSwap/LibSwap.sol
@@ -191,6 +191,12 @@ library LibSwap {
 
     /* ========== Smaller Specific Swap Functions ========== */
 
+    /**
+     * @notice                  Swaps a given amount of USDC for KLIMA using Sushiswap
+     * @param sourceAmount      Amount of USDC to swap
+     * @param klimaAmount       Amount of KLIMA to swap for
+     * @return klimaReceived    Amount of KLIMA received
+     */
     function swapToKlimaFromUsdc(uint256 sourceAmount, uint256 klimaAmount) internal returns (uint256 klimaReceived) {
         address[] memory path = new address[](2);
         path[0] = C.usdc();
@@ -199,11 +205,17 @@ library LibSwap {
         return _performToExactSwap(0, C.sushiRouter(), path, sourceAmount, klimaAmount);
     }
 
-    function swapToKlimaFromOther(
-        address sourceToken,
-        uint256 sourceAmount,
-        uint256 klimaAmount
-    ) internal returns (uint256 klimaReceived) {
+    /**
+     * @notice                  Swaps from arbitrary token routed through USDC for KLIMA
+     * @param sourceToken       Source token provided to swap
+     * @param sourceAmount      Amount of source token to swap
+     * @param klimaAmount       Amount of KLIMA to swap for
+     * @return klimaReceived    Amount of KLIMA received
+     */
+    function swapToKlimaFromOther(address sourceToken, uint256 sourceAmount, uint256 klimaAmount)
+        internal
+        returns (uint256 klimaReceived)
+    {
         address[] memory path = new address[](3);
         path[0] = sourceToken;
         path[1] = C.usdc();
@@ -211,6 +223,14 @@ library LibSwap {
         return _performToExactSwap(0, C.sushiRouter(), path, sourceAmount, klimaAmount);
     }
 
+    /**
+     * @notice                  Performs a swap with Retirement Bonds for carbon to retire.
+     * @param sourceToken       Source token provided to swap
+     * @param carbonToken       Carbon token to receive
+     * @param sourceAmount      Amount of source token to swap
+     * @param carbonAmount      Amount of carbon token needed
+     * @return carbonRecieved   Amount of carbon token received from the swap
+     */
     function swapWithRetirementBonds(
         address sourceToken,
         address carbonToken,
@@ -228,11 +248,8 @@ library LibSwap {
         if (sourceToken == C.usdc()) {
             sourceAmount = swapToKlimaFromUsdc(sourceAmount, LibTreasurySwap.getAmountIn(carbonToken, carbonAmount));
         } else {
-            sourceAmount = swapToKlimaFromOther(
-                sourceToken,
-                sourceAmount,
-                LibTreasurySwap.getAmountIn(carbonToken, carbonAmount)
-            );
+            sourceAmount =
+                swapToKlimaFromOther(sourceToken, sourceAmount, LibTreasurySwap.getAmountIn(carbonToken, carbonAmount));
         }
 
         LibTreasurySwap.swapToExact(carbonToken, sourceAmount, carbonAmount);

--- a/test/infinity/Bridge/C3.RedeemPoolDefault_NBO.t.sol
+++ b/test/infinity/Bridge/C3.RedeemPoolDefault_NBO.t.sol
@@ -31,6 +31,7 @@ contract RedeemNBODefaultTest is TestHelper, AssertionHelper {
     address WSKLIMA;
     address NBO;
     address DEFAULT_PROJECT;
+    address KLIMA_RETIREMENT_BOND;
 
     uint defaultCarbonRetireAmount = 100 * 1e18;
 
@@ -48,6 +49,7 @@ contract RedeemNBODefaultTest is TestHelper, AssertionHelper {
         SKLIMA = constantsFacet.sKlima();
         WSKLIMA = constantsFacet.wsKlima();
         NBO = constantsFacet.nbo();
+        KLIMA_RETIREMENT_BOND = constantsFacet.klimaRetirementBond();
 
         DEFAULT_PROJECT = IC3Pool(NBO).getFreeRedeemAddresses()[0];
 
@@ -95,6 +97,7 @@ contract RedeemNBODefaultTest is TestHelper, AssertionHelper {
         uint sourceAmount = getSourceTokens(sourceToken, redeemAmount);
 
         uint poolBalance = IERC20(DEFAULT_PROJECT).balanceOf(constantsFacet.nbo());
+        uint bondBalance = IERC20(NBO).balanceOf(KLIMA_RETIREMENT_BOND);
 
         if (redeemAmount > poolBalance || redeemAmount == 0) {
             console.log("Balance greater than pool");
@@ -124,6 +127,9 @@ contract RedeemNBODefaultTest is TestHelper, AssertionHelper {
             // No tokens left in contract
             assertZeroTokenBalance(DEFAULT_PROJECT, diamond);
             assertZeroTokenBalance(NBO, diamond);
+
+            // Retirement bonds were not used
+            assertEq(bondBalance, IERC20(NBO).balanceOf(KLIMA_RETIREMENT_BOND));
 
             // Caller has default project tokens
             assertEq(projectTokens[0], DEFAULT_PROJECT);

--- a/test/infinity/Bridge/C3.RedeemPoolDefault_UBO.t.sol
+++ b/test/infinity/Bridge/C3.RedeemPoolDefault_UBO.t.sol
@@ -31,6 +31,7 @@ contract RedeemUBODefaultTest is TestHelper, AssertionHelper {
     address WSKLIMA;
     address UBO;
     address DEFAULT_PROJECT;
+    address KLIMA_RETIREMENT_BOND;
 
     uint defaultCarbonRetireAmount = 100 * 1e18;
 
@@ -48,6 +49,7 @@ contract RedeemUBODefaultTest is TestHelper, AssertionHelper {
         SKLIMA = constantsFacet.sKlima();
         WSKLIMA = constantsFacet.wsKlima();
         UBO = constantsFacet.ubo();
+        KLIMA_RETIREMENT_BOND = constantsFacet.klimaRetirementBond();
 
         DEFAULT_PROJECT = IC3Pool(UBO).getFreeRedeemAddresses()[0];
 
@@ -95,6 +97,8 @@ contract RedeemUBODefaultTest is TestHelper, AssertionHelper {
         uint sourceAmount = getSourceTokens(sourceToken, redeemAmount);
 
         uint poolBalance = IERC20(DEFAULT_PROJECT).balanceOf(constantsFacet.ubo());
+        uint bondBalance = IERC20(UBO).balanceOf(KLIMA_RETIREMENT_BOND);
+
 
         if (redeemAmount > poolBalance || redeemAmount == 0) {
             console.log("Balance greater than pool");
@@ -124,6 +128,9 @@ contract RedeemUBODefaultTest is TestHelper, AssertionHelper {
             // No tokens left in contract
             assertZeroTokenBalance(DEFAULT_PROJECT, diamond);
             assertZeroTokenBalance(UBO, diamond);
+
+            // Retirement bonds were not used
+            assertEq(bondBalance, IERC20(UBO).balanceOf(KLIMA_RETIREMENT_BOND));
 
             // Caller has default project tokens
             assertEq(projectTokens[0], DEFAULT_PROJECT);

--- a/test/infinity/Bridge/C3.RedeemPoolSpecific_NBO.t.sol
+++ b/test/infinity/Bridge/C3.RedeemPoolSpecific_NBO.t.sol
@@ -31,6 +31,7 @@ contract RedeemNBOSpecificTest is TestHelper, AssertionHelper {
     address WSKLIMA;
     address NBO;
     address[] projects;
+    address KLIMA_RETIREMENT_BOND;
 
     uint defaultCarbonRetireAmount = 100 * 1e18;
 
@@ -48,6 +49,7 @@ contract RedeemNBOSpecificTest is TestHelper, AssertionHelper {
         SKLIMA = constantsFacet.sKlima();
         WSKLIMA = constantsFacet.wsKlima();
         NBO = constantsFacet.nbo();
+        KLIMA_RETIREMENT_BOND = constantsFacet.klimaRetirementBond();
 
         projects = IC3Pool(NBO).getERC20Tokens();
 
@@ -107,6 +109,7 @@ contract RedeemNBOSpecificTest is TestHelper, AssertionHelper {
         uint sourceAmount = getSourceTokens(sourceToken, redeemAmount);
 
         uint poolBalance = IERC20(specificProject).balanceOf(constantsFacet.nbo());
+        uint bondBalance = IERC20(NBO).balanceOf(KLIMA_RETIREMENT_BOND);
 
         if (redeemAmount > poolBalance || redeemAmount == 0) {
             console.log("Balance greater than pool");
@@ -139,6 +142,9 @@ contract RedeemNBOSpecificTest is TestHelper, AssertionHelper {
             assertZeroTokenBalance(specificProject, diamond);
             assertZeroTokenBalance(NBO, diamond);
 
+            // Retirement bonds were not used
+            assertEq(bondBalance, IERC20(NBO).balanceOf(KLIMA_RETIREMENT_BOND));
+            
             // Caller has default project tokens
             assertEq(redeemAmount, amounts[0]);
             assertEq(IERC20(specificProject).balanceOf(address(this)), amounts[0]);

--- a/test/infinity/Bridge/C3.RedeemPoolSpecific_UBO.t.sol
+++ b/test/infinity/Bridge/C3.RedeemPoolSpecific_UBO.t.sol
@@ -31,6 +31,7 @@ contract RedeemUBOSpecificTest is TestHelper, AssertionHelper {
     address WSKLIMA;
     address UBO;
     address[] projects;
+    address KLIMA_RETIREMENT_BOND;
 
     uint defaultCarbonRetireAmount = 100 * 1e18;
 
@@ -48,6 +49,7 @@ contract RedeemUBOSpecificTest is TestHelper, AssertionHelper {
         SKLIMA = constantsFacet.sKlima();
         WSKLIMA = constantsFacet.wsKlima();
         UBO = constantsFacet.ubo();
+        KLIMA_RETIREMENT_BOND = constantsFacet.klimaRetirementBond();
 
         projects = IC3Pool(UBO).getERC20Tokens();
 
@@ -107,6 +109,7 @@ contract RedeemUBOSpecificTest is TestHelper, AssertionHelper {
         uint sourceAmount = getSourceTokens(sourceToken, redeemAmount);
 
         uint poolBalance = IERC20(specificProject).balanceOf(constantsFacet.ubo());
+        uint bondBalance = IERC20(UBO).balanceOf(KLIMA_RETIREMENT_BOND);
 
         if (redeemAmount > poolBalance || redeemAmount == 0) {
             console.log("Balance greater than pool");
@@ -138,6 +141,9 @@ contract RedeemUBOSpecificTest is TestHelper, AssertionHelper {
             // No tokens left in contract
             assertZeroTokenBalance(specificProject, diamond);
             assertZeroTokenBalance(UBO, diamond);
+
+            // Retirement bonds were not used
+            assertEq(bondBalance, IERC20(UBO).balanceOf(KLIMA_RETIREMENT_BOND));
 
             // Caller has default project tokens
             assertEq(redeemAmount, amounts[0]);

--- a/test/infinity/Bridge/Toucan.RedeemPoolDefault_BCT.t.sol
+++ b/test/infinity/Bridge/Toucan.RedeemPoolDefault_BCT.t.sol
@@ -31,6 +31,7 @@ contract RedeemToucanPoolDefaultBCTTest is TestHelper, AssertionHelper {
     address WSKLIMA;
     address BCT;
     address DEFAULT_PROJECT;
+    address KLIMA_RETIREMENT_BOND;
 
     function setUp() public {
         addConstantsGetter(diamond);
@@ -48,6 +49,7 @@ contract RedeemToucanPoolDefaultBCTTest is TestHelper, AssertionHelper {
         BCT = constantsFacet.bct();
 
         DEFAULT_PROJECT = IToucanPool(BCT).getScoredTCO2s()[0];
+        KLIMA_RETIREMENT_BOND = constantsFacet.klimaRetirementBond();
 
         upgradeCurrentDiamond(diamond);
         sendDustToTreasury(diamond);
@@ -97,6 +99,7 @@ contract RedeemToucanPoolDefaultBCTTest is TestHelper, AssertionHelper {
         uint sourceAmount = getSourceTokens(sourceToken, redeemAmount);
 
         uint poolBalance = IERC20(DEFAULT_PROJECT).balanceOf(constantsFacet.bct());
+        uint bondBalance = IERC20(BCT).balanceOf(KLIMA_RETIREMENT_BOND);
 
         if (redeemAmount == 0) {
             vm.expectRevert();
@@ -123,6 +126,9 @@ contract RedeemToucanPoolDefaultBCTTest is TestHelper, AssertionHelper {
             // No tokens left in contract
             assertZeroTokenBalance(DEFAULT_PROJECT, diamond);
             assertZeroTokenBalance(BCT, diamond);
+
+            // Retirement bonds were not used
+            assertEq(bondBalance, IERC20(BCT).balanceOf(KLIMA_RETIREMENT_BOND));
 
             // Caller has default project tokens
             assertEq(projectTokens[0], DEFAULT_PROJECT);

--- a/test/infinity/Bridge/Toucan.RedeemPoolDefault_NCT.t.sol
+++ b/test/infinity/Bridge/Toucan.RedeemPoolDefault_NCT.t.sol
@@ -31,6 +31,7 @@ contract RedeemToucanPoolDefaultNCTTest is TestHelper, AssertionHelper {
     address WSKLIMA;
     address NCT;
     address DEFAULT_PROJECT;
+    address KLIMA_RETIREMENT_BOND;
 
     function setUp() public {
         addConstantsGetter(diamond);
@@ -48,6 +49,7 @@ contract RedeemToucanPoolDefaultNCTTest is TestHelper, AssertionHelper {
         NCT = constantsFacet.nct();
 
         DEFAULT_PROJECT = IToucanPool(NCT).getScoredTCO2s()[0];
+        KLIMA_RETIREMENT_BOND = constantsFacet.klimaRetirementBond();
 
         upgradeCurrentDiamond(diamond);
         sendDustToTreasury(diamond);
@@ -93,6 +95,7 @@ contract RedeemToucanPoolDefaultNCTTest is TestHelper, AssertionHelper {
     function redeemNCT(address sourceToken, uint redeemAmount) internal {
         vm.assume(redeemAmount < (IERC20(NCT).balanceOf(SUSHI_LP) * 10) / 100);
         uint sourceAmount = getSourceTokens(sourceToken, redeemAmount);
+        uint bondBalance = IERC20(NCT).balanceOf(KLIMA_RETIREMENT_BOND);
 
         if (redeemAmount == 0) {
             vm.expectRevert();
@@ -119,6 +122,9 @@ contract RedeemToucanPoolDefaultNCTTest is TestHelper, AssertionHelper {
             // No tokens left in contract
             assertZeroTokenBalance(DEFAULT_PROJECT, diamond);
             assertZeroTokenBalance(NCT, diamond);
+
+            // Retirement bonds were not used
+            assertEq(bondBalance, IERC20(NCT).balanceOf(KLIMA_RETIREMENT_BOND));
 
             // Caller has default project tokens
             assertEq(projectTokens[0], DEFAULT_PROJECT);

--- a/test/infinity/Bridge/Toucan.RedeemPoolSpecific_BCT.t.sol
+++ b/test/infinity/Bridge/Toucan.RedeemPoolSpecific_BCT.t.sol
@@ -31,6 +31,7 @@ contract RedeemToucanPoolDefaultBCTTest is TestHelper, AssertionHelper {
     address WSKLIMA;
     address BCT;
     address[] projects;
+    address KLIMA_RETIREMENT_BOND;
 
     function setUp() public {
         addConstantsGetter(diamond);
@@ -48,6 +49,7 @@ contract RedeemToucanPoolDefaultBCTTest is TestHelper, AssertionHelper {
         BCT = constantsFacet.bct();
 
         projects = IToucanPool(BCT).getScoredTCO2s();
+        KLIMA_RETIREMENT_BOND = constantsFacet.klimaRetirementBond();
 
         upgradeCurrentDiamond(diamond);
         sendDustToTreasury(diamond);
@@ -108,6 +110,7 @@ contract RedeemToucanPoolDefaultBCTTest is TestHelper, AssertionHelper {
         amountRedeem[0] = redeemAmount;
 
         uint poolBalance = IERC20(specificProject).balanceOf(BCT);
+        uint bondBalance = IERC20(BCT).balanceOf(KLIMA_RETIREMENT_BOND);
 
         if (redeemAmount > poolBalance || redeemAmount == 0) {
             vm.expectRevert();
@@ -135,6 +138,9 @@ contract RedeemToucanPoolDefaultBCTTest is TestHelper, AssertionHelper {
             // No tokens left in contract
             assertZeroTokenBalance(specificProject, diamond);
             assertZeroTokenBalance(BCT, diamond);
+
+            // Retirement bonds were not used
+            assertEq(bondBalance, IERC20(BCT).balanceOf(KLIMA_RETIREMENT_BOND));
 
             // Caller has default project tokens
             assertEq(redeemAmount, amounts[0]);

--- a/test/infinity/Bridge/Toucan.RedeemPoolSpecific_NCT.t.sol
+++ b/test/infinity/Bridge/Toucan.RedeemPoolSpecific_NCT.t.sol
@@ -31,6 +31,7 @@ contract RedeemToucanPoolDefaultNCTTest is TestHelper, AssertionHelper {
     address WSKLIMA;
     address NCT;
     address[] projects;
+    address KLIMA_RETIREMENT_BOND;
 
     function setUp() public {
         addConstantsGetter(diamond);
@@ -48,6 +49,7 @@ contract RedeemToucanPoolDefaultNCTTest is TestHelper, AssertionHelper {
         NCT = constantsFacet.nct();
 
         projects = IToucanPool(NCT).getScoredTCO2s();
+        KLIMA_RETIREMENT_BOND = constantsFacet.klimaRetirementBond();
 
         upgradeCurrentDiamond(diamond);
         sendDustToTreasury(diamond);
@@ -108,6 +110,7 @@ contract RedeemToucanPoolDefaultNCTTest is TestHelper, AssertionHelper {
         amountRedeem[0] = redeemAmount;
 
         uint poolBalance = IERC20(specificProject).balanceOf(NCT);
+        uint bondBalance = IERC20(NCT).balanceOf(KLIMA_RETIREMENT_BOND);
 
         if (redeemAmount > poolBalance || redeemAmount == 0) {
             vm.expectRevert();
@@ -135,6 +138,9 @@ contract RedeemToucanPoolDefaultNCTTest is TestHelper, AssertionHelper {
             // No tokens left in contract
             assertZeroTokenBalance(specificProject, diamond);
             assertZeroTokenBalance(NCT, diamond);
+
+            // Retirement bonds were not used
+            assertEq(bondBalance, IERC20(NCT).balanceOf(KLIMA_RETIREMENT_BOND));
 
             // Caller has default project tokens
             assertEq(redeemAmount, amounts[0]);

--- a/test/infinity/RetirementQuoter.t.sol
+++ b/test/infinity/RetirementQuoter.t.sol
@@ -1,0 +1,149 @@
+pragma solidity ^0.8.16;
+
+import {RetireSourceFacet} from "../../src/infinity/facets/Retire/RetireSourceFacet.sol";
+import {RetirementQuoter} from "../../src/infinity/facets/RetirementQuoter.sol";
+import {LibRetire} from "../../src/infinity/libraries/LibRetire.sol";
+import {LibKlima} from "../../src/infinity/libraries/LibKlima.sol";
+import {LibToucanCarbon} from "../../src/infinity/libraries/Bridges/LibToucanCarbon.sol";
+import {LibTransfer} from "../../src/infinity/libraries/Token/LibTransfer.sol";
+import {IToucanPool} from "../../src/infinity/interfaces/IToucan.sol";
+
+import "./TestHelper.sol";
+import "../helpers/AssertionHelper.sol";
+
+import {console2} from "../../lib/forge-std/src/console2.sol";
+
+contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
+    RetirementQuoter quoterFacet;
+    ConstantsGetter constantsFacet;
+
+    // Addresses defined in .env
+    address beneficiaryAddress = vm.envAddress("BENEFICIARY_ADDRESS");
+    address diamond = vm.envAddress("INFINITY_ADDRESS");
+    address SUSHI_LP = vm.envAddress("SUSHI_BCT_LP");
+
+
+    // Addresses pulled from current diamond constants
+    address USDC;
+    address KLIMA;
+    address BCT;
+
+    // Other static values for fee calcs
+    uint256 feeDivider = 10_000;
+    uint256 bctRedeemFee = 2_500;
+    uint256 infinityFee = 100;
+
+    function setUp() public {
+        addConstantsGetter(diamond);
+        quoterFacet = RetirementQuoter(diamond);
+        constantsFacet = ConstantsGetter(diamond);
+
+        USDC = constantsFacet.usdc();
+        KLIMA = constantsFacet.klima();
+        BCT = constantsFacet.bct();
+
+        upgradeCurrentDiamond(diamond);
+        sendDustToTreasury(diamond);
+        // fundRetirementBonds(constantsFacet.klimaRetirementBond());
+    }
+
+    function test_infinity_retirementQuoter_defaultRetire_noBonds_USDC(uint amount) public {
+        vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
+
+        // Account for fees
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider);
+
+        uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(USDC, BCT, totalCarbon);
+        uint256 retireResult = quoterFacet.getSourceAmountDefaultRetirement(USDC, BCT, amount);
+
+        assertEq(swapResult, retireResult);
+    }
+
+    function test_infinity_retirementQuoter_defaultRetire_noBonds_KLIMA(uint amount) public {
+        vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
+
+        // Account for fees
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider);
+
+        uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(KLIMA, BCT, totalCarbon);
+        uint256 retireResult = quoterFacet.getSourceAmountDefaultRetirement(KLIMA, BCT, amount);
+
+        assertEq(swapResult, retireResult);
+    }
+
+    function test_infinity_retirementQuoter_defaultRetire_withBonds_USDC(uint amount) public {
+        vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
+        fundRetirementBonds(constantsFacet.klimaRetirementBond());
+
+        // Account for fees
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider);
+
+        uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(USDC, BCT, totalCarbon);
+        uint256 retireResult = quoterFacet.getSourceAmountDefaultRetirement(USDC, BCT, amount);
+
+        assert(swapResult >= retireResult);
+    }
+
+    function test_infinity_retirementQuoter_defaultRetire_withBonds_KLIMA(uint amount) public {
+        vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
+        fundRetirementBonds(constantsFacet.klimaRetirementBond());
+
+        // Account for fees
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider);
+
+        uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(KLIMA, BCT, totalCarbon);
+        uint256 retireResult = quoterFacet.getSourceAmountDefaultRetirement(KLIMA, BCT, amount);
+
+        assert(swapResult >= retireResult);
+    }
+
+    function test_infinity_retirementQuoter_specificRetire_noBonds_USDC(uint amount) public {
+        vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
+
+        // Account for fees
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider) + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
+
+        uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(USDC, BCT, totalCarbon);
+        uint256 retireResult = quoterFacet.getSourceAmountSpecificRetirement(USDC, BCT, amount);
+
+        assertEq(swapResult, retireResult);
+    }
+
+    function test_infinity_retirementQuoter_specificRetire_noBonds_KLIMA(uint amount) public {
+        vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
+
+        // Account for fees
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider) + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
+
+        uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(KLIMA, BCT, totalCarbon);
+        uint256 retireResult = quoterFacet.getSourceAmountSpecificRetirement(KLIMA, BCT, amount);
+
+        assertEq(swapResult, retireResult);
+    }
+
+    function test_infinity_retirementQuoter_specificRetire_withBonds_USDC(uint amount) public {
+        vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
+        fundRetirementBonds(constantsFacet.klimaRetirementBond());
+
+        // Account for fees
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider) + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
+
+        uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(USDC, BCT, totalCarbon);
+        uint256 retireResult = quoterFacet.getSourceAmountSpecificRetirement(USDC, BCT, amount);
+
+        assert(swapResult >= retireResult);
+    }
+
+    function test_infinity_retirementQuoter_specificRetire_withBonds_KLIMA(uint amount) public {
+        vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
+        fundRetirementBonds(constantsFacet.klimaRetirementBond());
+        
+        // Account for fees
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider) + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
+
+        uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(KLIMA, BCT, totalCarbon);
+        uint256 retireResult = quoterFacet.getSourceAmountSpecificRetirement(KLIMA, BCT, amount);
+
+        assert(swapResult >= retireResult);
+    }
+}

--- a/test/infinity/TestHelper.sol
+++ b/test/infinity/TestHelper.sol
@@ -191,9 +191,12 @@ abstract contract TestHelper is Test, HelperContract {
         c3RedeemF = new RedeemC3PoolFacet();
         toucanRedeemF = new RedeemToucanPoolFacet();
         retirementQuoterF = new RetirementQuoter();
+        retireCarbonF = new RetireCarbonFacet();
+        retireSourceF = new RetireSourceFacet();
+
 
         // FacetCut array which contains the three standard facets to be added
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](3);
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](5);
 
         // Klima Infinity specific facets
 
@@ -217,6 +220,20 @@ abstract contract TestHelper is Test, HelperContract {
                 facetAddress: address(retirementQuoterF),
                 action: IDiamondCut.FacetCutAction.Replace,
                 functionSelectors: generateSelectors("RetirementQuoter")
+            })
+        );
+        cut[3] = (
+            IDiamondCut.FacetCut({
+                facetAddress: address(retireCarbonF),
+                action: IDiamondCut.FacetCutAction.Replace,
+                functionSelectors: generateSelectors("RetireCarbonFacet")
+            })
+        );
+        cut[4] = (
+            IDiamondCut.FacetCut({
+                facetAddress: address(retireSourceF),
+                action: IDiamondCut.FacetCutAction.Replace,
+                functionSelectors: generateSelectors("RetireSourceFacet")
             })
         );
 

--- a/test/infinity/TestHelper.sol
+++ b/test/infinity/TestHelper.sol
@@ -189,16 +189,11 @@ abstract contract TestHelper is Test, HelperContract {
 
         //deploy facets and init contract
         c3RedeemF = new RedeemC3PoolFacet();
-        c3RetireF = new RetireC3C3TFacet();
         toucanRedeemF = new RedeemToucanPoolFacet();
-        toucanRetireF = new RetireToucanTCO2Facet();
-        retireCarbonF = new RetireCarbonFacet();
-        retireInfoF = new RetireInfoFacet();
-        retireSourceF = new RetireSourceFacet();
         retirementQuoterF = new RetirementQuoter();
 
         // FacetCut array which contains the three standard facets to be added
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](9);
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](3);
 
         // Klima Infinity specific facets
 
@@ -212,75 +207,16 @@ abstract contract TestHelper is Test, HelperContract {
 
         cut[1] = (
             IDiamondCut.FacetCut({
-                facetAddress: address(c3RetireF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireC3C3TFacet")
-            })
-        );
-
-        cut[2] = (
-            IDiamondCut.FacetCut({
                 facetAddress: address(toucanRedeemF),
                 action: IDiamondCut.FacetCutAction.Replace,
                 functionSelectors: generateSelectors("RedeemToucanPoolFacet")
             })
         );
-
-        cut[3] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(toucanRetireF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireToucanTCO2Facet")
-            })
-        );
-
-        cut[4] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(retireCarbonF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireCarbonFacet")
-            })
-        );
-
-        cut[5] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(retireInfoF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireInfoFacet")
-            })
-        );
-
-        cut[6] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(retireSourceF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireSourceFacet")
-            })
-        );
-
-        bytes4[] memory currentSelectors = new bytes4[](5);
-        currentSelectors[0] = bytes4(0xf8262473);
-        currentSelectors[1] = bytes4(0xf0ff264c);
-        currentSelectors[2] = bytes4(0x16950775);
-        currentSelectors[3] = bytes4(0x79f5e053);
-        currentSelectors[4] = bytes4(0x7eed24a2);
-        bytes4[] memory newSelectors = new bytes4[](2);
-        newSelectors[0] = bytes4(0x8298360e);
-        newSelectors[1] = bytes4(0x58bdb8e8);
-
-        cut[7] = (
+        cut[2] = (
             IDiamondCut.FacetCut({
                 facetAddress: address(retirementQuoterF),
                 action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: currentSelectors
-            })
-        );
-
-        cut[8] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(retirementQuoterF),
-                action: IDiamondCut.FacetCutAction.Add,
-                functionSelectors: newSelectors
+                functionSelectors: generateSelectors("RetirementQuoter")
             })
         );
 


### PR DESCRIPTION
- Updates RetirementQuoter to fetch a price via Retirement Bonds if they can fill the order.
- Move the Retirement Bond swap logic from `LibSwap` to the retirement facets to enforce bonds only being used for retirements.
- Update pool redeem tests to check that retirement bond balance does not change after a redemption.

Resolves #47 