### PR TITLE
Aggregator: Add direct retirement from Carbonmark listing

### DIFF
--- a/abi/KlimaInfinity.json
+++ b/abi/KlimaInfinity.json
@@ -1260,6 +1260,209 @@
         "type": "function"
     },
     {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "carbonToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "getRetireAmountSourceDefault",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountOut",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "carbonToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "getRetireAmountSourceSpecific",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountOut",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "carbonToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "redeemAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "getSourceAmountDefaultRedeem",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "carbonToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "retireAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "getSourceAmountDefaultRetirement",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "carbonToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "redeemAmounts",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "getSourceAmountSpecificRedeem",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "carbonToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "retireAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "getSourceAmountSpecificRetirement",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sourceToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "carbonToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amountOut",
+                "type": "uint256"
+            }
+        ],
+        "name": "getSourceAmountSwapOnly",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
         "anonymous": false,
         "inputs": [
             {

--- a/abi/KlimaInfinity.json
+++ b/abi/KlimaInfinity.json
@@ -914,6 +914,87 @@
     {
         "inputs": [
             {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "id",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "account",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "remainingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "unitPrice",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct ICarbonmark.CreditListing",
+                "name": "listing",
+                "type": "tuple"
+            },
+            {
+                "internalType": "uint256",
+                "name": "maxAmountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "retireAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "string",
+                "name": "retiringEntityString",
+                "type": "string"
+            },
+            {
+                "internalType": "address",
+                "name": "beneficiaryAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "beneficiaryString",
+                "type": "string"
+            },
+            {
+                "internalType": "string",
+                "name": "retirementMessage",
+                "type": "string"
+            },
+            {
+                "internalType": "enum LibTransfer.From",
+                "name": "fromMode",
+                "type": "uint8"
+            }
+        ],
+        "name": "retireCarbonmarkListing",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "retirementIndex",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
                 "internalType": "address",
                 "name": "account",
                 "type": "address"

--- a/src/infinity/C.sol
+++ b/src/infinity/C.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.8.0;
 
 library C {
     // Chain
-    uint private constant CHAIN_ID = 137; // Polygon
+    uint256 private constant CHAIN_ID = 137; // Polygon
 
     // Klima Protocol Contracts
     address private constant KLIMA = 0x4e78011Ce80ee02d2c3e649Fb657E45898257815;
@@ -27,6 +27,9 @@ library C {
     address private constant SUSHI_BENTO = 0x0319000133d3AdA02600f0875d2cf03D442C3367;
     address private constant SUSHI_TRIDENT_POLYGON = 0xc5017BE80b4446988e8686168396289a9A62668E;
 
+    // Marketplace contracts
+    address private constant CARBONMARK = 0x52F42b41acDa12a53477dc0BA24297c78a9b7DeC;
+
     /* Carbon Pools */
     // Toucan
     address private constant BCT = 0x2F800Db0fdb5223b3C3f354886d907A671414A7F;
@@ -44,6 +47,8 @@ library C {
     address private constant MOSS_CARBON_CHAIN = 0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8;
     address private constant KLIMA_CARBON_RETIREMENTS = 0xac298CD34559B9AcfaedeA8344a977eceff1C0Fd;
     address private constant KLIMA_RETIREMENT_BOND = 0xa595f0d598DaF144e5a7ca91E6D9A5bAA09dDeD0;
+    address constant TOUCAN_REGISTRY = 0x263fA1c180889b3a3f46330F32a4a23287E99FC9;
+    address constant C3_PROJECT_FACTORY = 0xa4c951B30952f5E2feFC8a92F4d3c7551925A63B;
 
     function toucanCert() internal pure returns (address) {
         return TOUCAN_RETIRE_CERT;
@@ -123,5 +128,17 @@ library C {
 
     function klimaRetirementBond() internal pure returns (address) {
         return KLIMA_RETIREMENT_BOND;
+    }
+
+    function toucanRegistry() internal pure returns (address) {
+        return TOUCAN_REGISTRY;
+    }
+
+    function c3ProjectFactory() internal pure returns (address) {
+        return C3_PROJECT_FACTORY;
+    }
+
+    function carbonmark() internal pure returns (address) {
+        return CARBONMARK;
     }
 }

--- a/src/infinity/C.sol
+++ b/src/infinity/C.sol
@@ -28,7 +28,7 @@ library C {
     address private constant SUSHI_TRIDENT_POLYGON = 0xc5017BE80b4446988e8686168396289a9A62668E;
 
     // Marketplace contracts
-    address private constant CARBONMARK = 0x52F42b41acDa12a53477dc0BA24297c78a9b7DeC;
+    address private constant CARBONMARK = 0x7B51dBc2A8fD98Fe0924416E628D5755f57eB821;
 
     /* Carbon Pools */
     // Toucan

--- a/src/infinity/facets/Retire/RetireCarbonmarkFacet.sol
+++ b/src/infinity/facets/Retire/RetireCarbonmarkFacet.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import {LibRetire, C, LibApprove} from "../../libraries/LibRetire.sol";
+import {ICarbonmark} from "../../interfaces/ICarbonmark.sol";
+import "../../ReentrancyGuard.sol";
+
+contract RetireCarbonmarkFacet is ReentrancyGuard {
+    event CarbonRetired(
+        LibRetire.CarbonBridge carbonBridge,
+        address indexed retiringAddress,
+        string retiringEntityString,
+        address indexed beneficiaryAddress,
+        string beneficiaryString,
+        string retirementMessage,
+        address indexed carbonPool,
+        address poolToken,
+        uint256 retiredAmount
+    );
+
+    /* ========== Retire directly from a Carbonmark listing ========== */
+
+    /**
+     * @notice                     Retires an exact amount of carbon using default redemption
+     * @param maxAmountIn          Maximum amount of USDC tokens to spend for this retirement
+     * @param retireAmount         The amount of carbon to retire
+     * @param retiringEntityString String description of the retiring entity
+     * @param beneficiaryAddress   0x address for the beneficiary
+     * @param beneficiaryString    String description of the beneficiary
+     * @param retirementMessage    String message for this specific retirement
+     * @param fromMode             From Mode for transfering tokens
+     * @return retirementIndex     The latest retirement index for the beneficiary address
+     */
+    function retireCarbonmarkListing(
+        ICarbonmark.CreditListing memory listing,
+        uint256 maxAmountIn,
+        uint256 retireAmount,
+        string memory retiringEntityString,
+        address beneficiaryAddress,
+        string memory beneficiaryString,
+        string memory retirementMessage,
+        LibTransfer.From fromMode
+    ) external payable nonReentrant returns (uint256 retirementIndex) {
+        require(retireAmount > 0, "Cannot retire zero tonnes");
+
+        LibTransfer.receiveToken(IERC20(C.usdc()), maxAmountIn, msg.sender, fromMode);
+
+        LibApprove.approveToken(IERC20(C.usdc()), C.carbonmark(), maxAmountIn);
+
+        ICarbonmark(C.carbonmark()).fillListing(
+            listing.id, listing.account, listing.token, listing.unitPrice, retireAmount, maxAmountIn
+        );
+
+        LibRetire.retireReceivedCreditToken(
+            listing.token,
+            retireAmount,
+            msg.sender,
+            retiringEntityString,
+            beneficiaryAddress,
+            beneficiaryString,
+            retirementMessage
+        );
+
+        return LibRetire.getTotalRetirements(beneficiaryAddress);
+    }
+}

--- a/src/infinity/interfaces/IC3.sol
+++ b/src/infinity/interfaces/IC3.sol
@@ -15,5 +15,9 @@ interface IC3Pool {
 }
 
 interface IC3ProjectToken {
-    function offsetFor(uint amount, address beneficiary, string memory transferee, string memory reason) external;
+    function offsetFor(uint256 amount, address beneficiary, string memory transferee, string memory reason) external;
+}
+
+interface IC3ProjectFactory {
+    function isTokenExists(address _address) external returns (bool);
 }

--- a/src/infinity/interfaces/ICarbonmark.sol
+++ b/src/infinity/interfaces/ICarbonmark.sol
@@ -1,0 +1,62 @@
+//SPDX-License-Identifier: Unlicensed
+pragma solidity ^0.8.16;
+
+interface ICarbonmark {
+    /**
+     * @notice Struct containing all of the detail information needed to fill a listing
+     * @param account Ethereum address of the account who owns the listing
+     * @param token Ethereum address of the token being listing
+     * @param originalAmount Original amount of the listing
+     * @param remainingAmount Remaining amount that can be filled on this listing
+     * @param unitPrice The unit price in USDC of the listing
+     * @param minFillAmount The minimum amount needed to purchase in order to fill the listing
+     * @param deadline The block timestamp at which this listing expires
+     */
+    struct CreditListing {
+        bytes32 id;
+        address account;
+        address token;
+        uint256 remainingAmount;
+        uint256 unitPrice;
+    }
+
+    /**
+     * @notice This function creates a new listing and returns the resulting listing ID
+     * @param token The token being listed
+     * @param amount The amount to be listed
+     * @param unitPrice The unit price in USDC to list. Should be provided in full form so a price of 2.5 USDC = input
+     * of 2500000
+     * @param minFillAmount The minimum number of tons needed to be purchased to fill this listing
+     * @param deadline The block timestamp at which this listing will expire
+     * @return id The ID of the listing that was created
+     */
+    function createListing(address token, uint256 amount, uint256 unitPrice, uint256 minFillAmount, uint256 deadline)
+        external
+        returns (bytes32 id);
+
+    /**
+     * @notice This function fills an existing listing
+     * @param id The listing ID to update
+     * @param listingAccount The account that created the listing you are filling
+     * @param listingToken The token you are swapping for
+     * @param listingUnitPrice The unit price per token to fill the listing
+     * @param amount Amount of the listing to fill
+     * @param maxCost Maximum cost in USDC for filling this listing
+     */
+    function fillListing(
+        bytes32 id,
+        address listingAccount,
+        address listingToken,
+        uint256 listingUnitPrice,
+        uint256 amount,
+        uint256 maxCost
+    ) external;
+
+    function getListingOwner(bytes32 id) external view returns (address);
+
+    function getUnitPrice(bytes32 id) external view returns (uint256);
+
+    function getRemainingAmount(bytes32 id) external view returns (uint256);
+
+    function getListingDeadline(bytes32 id) external view returns (uint256);
+}

--- a/src/infinity/interfaces/IToucan.sol
+++ b/src/infinity/interfaces/IToucan.sol
@@ -35,3 +35,7 @@ interface IToucanCarbonOffsets {
         uint amount
     ) external;
 }
+
+interface IToucanContractRegistry {
+    function isValidERC20(address erc20) external returns (bool);
+}

--- a/src/infinity/libraries/Bridges/LibC3Carbon.sol
+++ b/src/infinity/libraries/Bridges/LibC3Carbon.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.16;
 import "../LibRetire.sol";
 import "../Token/LibTransfer.sol";
 import "../../interfaces/IC3.sol";
+import "../../C.sol";
 
 import "lib/forge-std/src/console.sol";
 
@@ -257,5 +258,9 @@ library LibC3Carbon {
             LibTransfer.sendToken(IERC20(projectTokens[i]), redeemedAmounts[i], msg.sender, toMode);
         }
         return redeemedAmounts;
+    }
+
+    function isValid(address token) internal returns (bool) {
+        return IC3ProjectFactory(C.c3ProjectFactory()).isTokenExists(token);
     }
 }

--- a/src/infinity/libraries/Bridges/LibToucanCarbon.sol
+++ b/src/infinity/libraries/Bridges/LibToucanCarbon.sol
@@ -271,4 +271,8 @@ library LibToucanCarbon {
         }
         return redeemedAmounts;
     }
+
+    function isValid(address token) internal returns (bool) {
+        return IToucanContractRegistry(C.toucanRegistry()).isValidERC20(token);
+    }
 }

--- a/src/infinity/libraries/LibRetire.sol
+++ b/src/infinity/libraries/LibRetire.sol
@@ -141,6 +141,51 @@ library LibRetire {
         }
     }
 
+    /* ========== Credit Token Direct Retirements ========== */
+
+    /**
+     * @notice                     Retire received carbon based on the bridge of the provided pool tokens using default redemption
+     * @param creditToken          Pool token used to retire
+     * @param amount               The amount of carbon to retire
+     * @param retiringEntityString String description of the retiring entity
+     * @param beneficiaryAddress   0x address for the beneficiary
+     * @param beneficiaryString    String description of the beneficiary
+     * @param retirementMessage    String message for this specific retirement
+     */
+    function retireReceivedCreditToken(
+        address creditToken,
+        uint256 amount,
+        address retiringAddress,
+        string memory retiringEntityString,
+        address beneficiaryAddress,
+        string memory beneficiaryString,
+        string memory retirementMessage
+    ) internal {
+        if (LibToucanCarbon.isValid(creditToken)) {
+            LibToucanCarbon.retireTCO2(
+                address(0), // Direct retirement, no pool token
+                creditToken,
+                amount,
+                retiringAddress,
+                retiringEntityString,
+                beneficiaryAddress,
+                beneficiaryString,
+                retirementMessage
+            );
+        } else if (LibC3Carbon.isValid(creditToken)) {
+            LibC3Carbon.retireC3T(
+                address(0), // Direct retirement, no pool token
+                creditToken,
+                amount,
+                retiringAddress,
+                retiringEntityString,
+                beneficiaryAddress,
+                beneficiaryString,
+                retirementMessage
+            );
+        }
+    }
+
     /**
      * @notice                     Additional function to handle the differences in wanting to fully retire x pool tokens specifically
      * @param poolToken            Pool token used to retire

--- a/src/infinity/mocks/ConstantsGetter.sol
+++ b/src/infinity/mocks/ConstantsGetter.sol
@@ -88,4 +88,8 @@ contract ConstantsGetter {
     function klimaRetirementBond() external pure returns (address) {
         return C.klimaRetirementBond();
     }
+
+    function carbonmark() external pure returns (address) {
+        return C.carbonmark();
+    }
 }

--- a/src/protocol/interfaces/IKLIMA.sol
+++ b/src/protocol/interfaces/IKLIMA.sol
@@ -13,15 +13,17 @@ interface IKlima is IERC20 {
 }
 
 interface IKlimaTreasury {
-    function excessReserves() external returns (uint);
+    function excessReserves() external returns (uint256);
 
-    function manage(address _token, uint _amount) external;
+    function manage(address _token, uint256 _amount) external;
 
     function queue(uint8 _managing, address _address) external returns (bool);
 
     function toggle(uint8 _managing, address _address, address _calculator) external returns (bool);
 
-    function ReserveManagerQueue(address _address) external returns (uint);
+    function ReserveManagerQueue(address _address) external returns (uint256);
+
+    function isReserveManager(address _address) external returns (bool);
 }
 
 interface IKlimaRetirementBond {

--- a/test/infinity/Retire/RetireCarbonmarkListing.t.sol
+++ b/test/infinity/Retire/RetireCarbonmarkListing.t.sol
@@ -1,0 +1,155 @@
+pragma solidity ^0.8.16;
+
+import {RetireCarbonmarkFacet} from "../../../src/infinity/facets/Retire/RetireCarbonmarkFacet.sol";
+import {RetirementQuoter} from "../../../src/infinity/facets/RetirementQuoter.sol";
+import {LibRetire} from "../../../src/infinity/libraries/LibRetire.sol";
+import {LibToucanCarbon} from "../../../src/infinity/libraries/Bridges/LibToucanCarbon.sol";
+import {LibTransfer} from "../../../src/infinity/libraries/Token/LibTransfer.sol";
+import {IToucanPool} from "../../../src/infinity/interfaces/IToucan.sol";
+import {ICarbonmark} from "../../../src/infinity/interfaces/ICarbonmark.sol";
+
+import "../TestHelper.sol";
+import "../../helpers/AssertionHelper.sol";
+
+import {console2} from "../../../lib/forge-std/src/console2.sol";
+
+contract RetireCarbonmarkListing is TestHelper, AssertionHelper {
+    RetireCarbonmarkFacet retireCarbonmarkFacet;
+    RetirementQuoter quoterFacet;
+    ConstantsGetter constantsFacet;
+
+    // Retirement details
+    string beneficiary = "Test Beneficiary";
+    string message = "Test Message";
+    string entity = "Test Entity";
+
+    // Addresses defined in .env
+    address beneficiaryAddress = vm.envAddress("BENEFICIARY_ADDRESS");
+    address diamond = vm.envAddress("INFINITY_ADDRESS");
+    address WSKLIMA_HOLDER = vm.envAddress("WSKLIMA_HOLDER");
+    address SUSHI_LP = vm.envAddress("SUSHI_BCT_LP");
+    address PUBLIC_KEY = vm.envAddress("PUBLIC_KEY");
+
+    // Addresses pulled from current diamond constants
+    address KLIMA_TREASURY;
+    address STAKING;
+    address USDC;
+    address KLIMA;
+    address SKLIMA;
+    address WSKLIMA;
+    address BCT;
+    address DEFAULT_PROJECT;
+    address CARBONMARK;
+
+    function setUp() public {
+        addConstantsGetter(diamond);
+        retireCarbonmarkFacet = RetireCarbonmarkFacet(diamond);
+        quoterFacet = RetirementQuoter(diamond);
+        constantsFacet = ConstantsGetter(diamond);
+
+        KLIMA_TREASURY = constantsFacet.treasury();
+        STAKING = constantsFacet.staking();
+
+        USDC = constantsFacet.usdc();
+        KLIMA = constantsFacet.klima();
+        SKLIMA = constantsFacet.sKlima();
+        WSKLIMA = constantsFacet.wsKlima();
+        BCT = constantsFacet.bct();
+        CARBONMARK = constantsFacet.carbonmark();
+
+        DEFAULT_PROJECT = IToucanPool(BCT).getScoredTCO2s()[0];
+
+        upgradeCurrentDiamond(diamond);
+        sendDustToTreasury(diamond);
+        fundRetirementBonds(constantsFacet.klimaRetirementBond());
+    }
+
+    function test_infinity_retireCarbonmark_BCT() public {
+        address TCO2 = 0xb139C4cC9D20A3618E9a2268D73Eff18C496B991;
+        uint256 listingAmount = 1_250_000_000_000_000_000;
+        // create listing
+        swipeERC20Tokens(TCO2, listingAmount, PUBLIC_KEY, address(this));
+
+        IERC20(TCO2).approve(CARBONMARK, listingAmount);
+
+        bytes32 listingId =
+            ICarbonmark(CARBONMARK).createListing(TCO2, listingAmount, 5_000_000, 1e17, block.timestamp + 3600);
+
+        ICarbonmark.CreditListing memory listing =
+            ICarbonmark.CreditListing(listingId, address(this), TCO2, listingAmount, 5_000_000);
+
+        retireExactBCT(listing, 5e17);
+    }
+
+    function getSourceTokens(bytes32 listingId, uint256 retireAmount) internal returns (uint256 sourceAmount) {
+        vm.assume(retireAmount <= ICarbonmark(CARBONMARK).getRemainingAmount(listingId));
+
+        sourceAmount = ICarbonmark(CARBONMARK).getUnitPrice(listingId) * retireAmount / 1e18;
+
+        vm.assume(sourceAmount <= IERC20(USDC).balanceOf(KLIMA_TREASURY));
+
+        swipeERC20Tokens(USDC, sourceAmount, KLIMA_TREASURY, address(this));
+        IERC20(USDC).approve(diamond, sourceAmount);
+    }
+
+    function retireExactBCT(ICarbonmark.CreditListing memory listing, uint256 retireAmount) public {
+        uint256 sourceAmount = getSourceTokens(listing.id, retireAmount);
+
+        uint256 currentRetirements = LibRetire.getTotalRetirements(beneficiaryAddress);
+        uint256 currentTotalCarbon = LibRetire.getTotalCarbonRetired(beneficiaryAddress);
+
+        if (retireAmount == 0) {
+            vm.expectRevert();
+
+            retireCarbonmarkFacet.retireCarbonmarkListing(
+                listing,
+                sourceAmount,
+                retireAmount,
+                entity,
+                beneficiaryAddress,
+                beneficiary,
+                message,
+                LibTransfer.From.EXTERNAL
+            );
+        } else {
+            // Set up expectEmit
+            vm.expectEmit(true, true, true, true);
+
+            // Emit expected CarbonRetired event
+            emit LibToucanCarbon.CarbonRetired(
+                LibRetire.CarbonBridge.TOUCAN,
+                address(this),
+                entity,
+                beneficiaryAddress,
+                beneficiary,
+                message,
+                address(0),
+                DEFAULT_PROJECT,
+                retireAmount
+            );
+
+            uint256 retirementIndex = retireCarbonmarkFacet.retireCarbonmarkListing(
+                listing,
+                sourceAmount,
+                retireAmount,
+                entity,
+                beneficiaryAddress,
+                beneficiary,
+                message,
+                LibTransfer.From.EXTERNAL
+            );
+
+            // No tokens left in contract
+            assertZeroTokenBalance(USDC, diamond);
+            assertZeroTokenBalance(BCT, diamond);
+            assertZeroTokenBalance(DEFAULT_PROJECT, diamond);
+
+            // Return value matches
+            assertEq(LibRetire.getTotalRetirements(beneficiaryAddress), retirementIndex);
+
+            // Account state values updated
+            assertEq(LibRetire.getTotalRetirements(beneficiaryAddress), currentRetirements + 1);
+            assertEq(LibRetire.getTotalCarbonRetired(beneficiaryAddress), currentTotalCarbon + retireAmount);
+        }
+    }
+}

--- a/test/infinity/Retire/RetireExactSourceDefault.Moss.t.sol
+++ b/test/infinity/Retire/RetireExactSourceDefault.Moss.t.sol
@@ -56,27 +56,27 @@ contract RetireExactSourceDefaultMoss is TestHelper, AssertionHelper {
         fundRetirementBonds(constantsFacet.klimaRetirementBond());
     }
 
-    function test_infinity_retireExactSourceDefault_MCO2_MCO2(uint retireAmount) public {
+    function test_infinity_retireExactSourceDefault_MCO2_MCO2(uint256 retireAmount) public {
         retireExactMoss(MCO2, retireAmount);
     }
 
-    function test_infinity_retireExactSourceDefault_MCO2_USDC(uint retireAmount) public {
+    function test_infinity_retireExactSourceDefault_MCO2_USDC(uint256 retireAmount) public {
         retireExactMoss(USDC, retireAmount);
     }
 
-    function test_infinity_retireExactSourceDefault_MCO2_KLIMA(uint retireAmount) public {
+    function test_infinity_retireExactSourceDefault_MCO2_KLIMA(uint256 retireAmount) public {
         retireExactMoss(KLIMA, retireAmount);
     }
 
-    function test_infinity_retireExactSourceDefault_MCO2_SKLIMA(uint retireAmount) public {
+    function test_infinity_retireExactSourceDefault_MCO2_SKLIMA(uint256 retireAmount) public {
         retireExactMoss(SKLIMA, retireAmount);
     }
 
-    function test_infinity_retireExactSourceDefault_MCO2_WSKLIMA(uint retireAmount) public {
+    function test_infinity_retireExactSourceDefault_MCO2_WSKLIMA(uint256 retireAmount) public {
         retireExactMoss(WSKLIMA, retireAmount);
     }
 
-    function getSourceTokens(address sourceToken, uint retireAmount) internal returns (uint sourceAmount) {
+    function getSourceTokens(address sourceToken, uint256 retireAmount) internal returns (uint256 sourceAmount) {
         /// @dev getting trade amount on zero output will revert
         if (retireAmount == 0 && sourceToken != MCO2) vm.expectRevert();
         sourceAmount = quoterFacet.getSourceAmountDefaultRetirement(sourceToken, MCO2, retireAmount);
@@ -93,12 +93,12 @@ contract RetireExactSourceDefaultMoss is TestHelper, AssertionHelper {
         IERC20(sourceToken).approve(diamond, sourceAmount);
     }
 
-    function retireExactMoss(address sourceToken, uint retireAmount) public {
+    function retireExactMoss(address sourceToken, uint256 retireAmount) public {
         vm.assume(retireAmount < (IERC20(MCO2).balanceOf(QUICKSWAP_LP) * 90) / 100);
-        uint sourceAmount = getSourceTokens(sourceToken, retireAmount);
+        uint256 sourceAmount = getSourceTokens(sourceToken, retireAmount);
 
-        uint currentRetirements = LibRetire.getTotalRetirements(beneficiaryAddress);
-        uint currentTotalCarbon = LibRetire.getTotalCarbonRetired(beneficiaryAddress);
+        uint256 currentRetirements = LibRetire.getTotalRetirements(beneficiaryAddress);
+        uint256 currentTotalCarbon = LibRetire.getTotalCarbonRetired(beneficiaryAddress);
 
         if (retireAmount == 0) {
             vm.expectRevert();
@@ -137,9 +137,7 @@ contract RetireExactSourceDefaultMoss is TestHelper, AssertionHelper {
 
             // Since the output from Trident isn't deterministic until the swap happens, check an approximation.
             assertApproxEqRel(
-                LibRetire.getTotalCarbonRetired(beneficiaryAddress),
-                currentTotalCarbon + retireAmount,
-                1e16
+                LibRetire.getTotalCarbonRetired(beneficiaryAddress), currentTotalCarbon + retireAmount, 1e19
             );
         }
     }

--- a/test/infinity/RetirementQuoter.t.sol
+++ b/test/infinity/RetirementQuoter.t.sol
@@ -22,7 +22,6 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
     address diamond = vm.envAddress("INFINITY_ADDRESS");
     address SUSHI_LP = vm.envAddress("SUSHI_BCT_LP");
 
-
     // Addresses pulled from current diamond constants
     address USDC;
     address KLIMA;
@@ -30,7 +29,7 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
 
     // Other static values for fee calcs
     uint256 feeDivider = 10_000;
-    uint256 bctRedeemFee = 2_500;
+    uint256 bctRedeemFee = 2500;
     uint256 infinityFee = 100;
 
     function setUp() public {
@@ -44,10 +43,11 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
 
         upgradeCurrentDiamond(diamond);
         sendDustToTreasury(diamond);
+        closeRetirementBonds(constantsFacet.klimaRetirementBond());
         // fundRetirementBonds(constantsFacet.klimaRetirementBond());
     }
 
-    function test_infinity_retirementQuoter_defaultRetire_noBonds_USDC(uint amount) public {
+    function test_infinity_retirementQuoter_defaultRetire_noBonds_USDC(uint256 amount) public {
         vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
 
         // Account for fees
@@ -59,7 +59,7 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
         assertEq(swapResult, retireResult);
     }
 
-    function test_infinity_retirementQuoter_defaultRetire_noBonds_KLIMA(uint amount) public {
+    function test_infinity_retirementQuoter_defaultRetire_noBonds_KLIMA(uint256 amount) public {
         vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
 
         // Account for fees
@@ -71,7 +71,7 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
         assertEq(swapResult, retireResult);
     }
 
-    function test_infinity_retirementQuoter_defaultRetire_withBonds_USDC(uint amount) public {
+    function test_infinity_retirementQuoter_defaultRetire_withBonds_USDC(uint256 amount) public {
         vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
         fundRetirementBonds(constantsFacet.klimaRetirementBond());
 
@@ -84,7 +84,7 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
         assert(swapResult >= retireResult);
     }
 
-    function test_infinity_retirementQuoter_defaultRetire_withBonds_KLIMA(uint amount) public {
+    function test_infinity_retirementQuoter_defaultRetire_withBonds_KLIMA(uint256 amount) public {
         vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
         fundRetirementBonds(constantsFacet.klimaRetirementBond());
 
@@ -97,11 +97,12 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
         assert(swapResult >= retireResult);
     }
 
-    function test_infinity_retirementQuoter_specificRetire_noBonds_USDC(uint amount) public {
+    function test_infinity_retirementQuoter_specificRetire_noBonds_USDC(uint256 amount) public {
         vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
 
         // Account for fees
-        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider) + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider)
+            + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
 
         uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(USDC, BCT, totalCarbon);
         uint256 retireResult = quoterFacet.getSourceAmountSpecificRetirement(USDC, BCT, amount);
@@ -109,11 +110,12 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
         assertEq(swapResult, retireResult);
     }
 
-    function test_infinity_retirementQuoter_specificRetire_noBonds_KLIMA(uint amount) public {
+    function test_infinity_retirementQuoter_specificRetire_noBonds_KLIMA(uint256 amount) public {
         vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
 
         // Account for fees
-        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider) + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider)
+            + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
 
         uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(KLIMA, BCT, totalCarbon);
         uint256 retireResult = quoterFacet.getSourceAmountSpecificRetirement(KLIMA, BCT, amount);
@@ -121,12 +123,13 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
         assertEq(swapResult, retireResult);
     }
 
-    function test_infinity_retirementQuoter_specificRetire_withBonds_USDC(uint amount) public {
+    function test_infinity_retirementQuoter_specificRetire_withBonds_USDC(uint256 amount) public {
         vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
         fundRetirementBonds(constantsFacet.klimaRetirementBond());
 
         // Account for fees
-        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider) + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider)
+            + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
 
         uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(USDC, BCT, totalCarbon);
         uint256 retireResult = quoterFacet.getSourceAmountSpecificRetirement(USDC, BCT, amount);
@@ -134,12 +137,13 @@ contract retireExactSourceSpecificToucan is TestHelper, AssertionHelper {
         assert(swapResult >= retireResult);
     }
 
-    function test_infinity_retirementQuoter_specificRetire_withBonds_KLIMA(uint amount) public {
+    function test_infinity_retirementQuoter_specificRetire_withBonds_KLIMA(uint256 amount) public {
         vm.assume(amount > 0 && amount < (IERC20(BCT).balanceOf(SUSHI_LP) * 50) / 100);
         fundRetirementBonds(constantsFacet.klimaRetirementBond());
-        
+
         // Account for fees
-        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider) + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
+        uint256 totalCarbon = amount + ((amount * infinityFee) / feeDivider)
+            + (((amount * feeDivider) / (feeDivider - bctRedeemFee)) - amount);
 
         uint256 swapResult = quoterFacet.getSourceAmountSwapOnly(KLIMA, BCT, totalCarbon);
         uint256 retireResult = quoterFacet.getSourceAmountSpecificRetirement(KLIMA, BCT, amount);

--- a/test/infinity/TestHelper.sol
+++ b/test/infinity/TestHelper.sol
@@ -304,6 +304,29 @@ abstract contract TestHelper is Test, HelperContract {
         vm.stopPrank();
     }
 
+    function closeRetirementBonds(address retirementBonds) internal {
+        // Assuming mainnet fork testing for the moment
+        address BCT = 0x2F800Db0fdb5223b3C3f354886d907A671414A7F;
+        address NCT = 0xD838290e877E0188a4A44700463419ED96c16107;
+        address MCO2 = 0xAa7DbD1598251f856C12f63557A4C4397c253Cea;
+        address UBO = 0x2B3eCb0991AF0498ECE9135bcD04013d7993110c;
+        address NBO = 0x6BCa3B77C1909Ce1a4Ba1A20d1103bDe8d222E48;
+
+        address allocator = IKlimaRetirementBond(retirementBonds).allocatorContract();
+
+        address owner = IRetirementBondAllocator(allocator).owner();
+
+        vm.startPrank(owner);
+
+        IRetirementBondAllocator(allocator).closeBonds(BCT);
+        IRetirementBondAllocator(allocator).closeBonds(NCT);
+        IRetirementBondAllocator(allocator).closeBonds(MCO2);
+        IRetirementBondAllocator(allocator).closeBonds(UBO);
+        IRetirementBondAllocator(allocator).closeBonds(NBO);
+
+        vm.stopPrank();
+    }
+
     function maxBondAmount(address token, address allocator) internal returns (uint256 maxAmount) {
         address treasury = vm.envAddress("KLIMA_TREASURY_ADDRESS");
         uint256 maxReserve = IRetirementBondAllocator(allocator).maxReservePercent();


### PR DESCRIPTION
With the re-enabling of listings on Carbonmark, add a facet to the aggregator to allow for direct retirement of a Carbonmark listing as a source in addition to pooled credits.