### PR TITLE
Enable ICR support

### DIFF
--- a/abi/KlimaInfinity.json
+++ b/abi/KlimaInfinity.json
@@ -255,6 +255,60 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "projectToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "string",
+                "name": "retiringEntityString",
+                "type": "string"
+            },
+            {
+                "internalType": "address",
+                "name": "beneficiaryAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "beneficiaryString",
+                "type": "string"
+            },
+            {
+                "internalType": "string",
+                "name": "retirementMessage",
+                "type": "string"
+            },
+            {
+                "internalType": "enum LibTransfer.From",
+                "name": "fromMode",
+                "type": "uint8"
+            }
+        ],
+        "name": "icrRetireExactCarbon",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "retirementIndex",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
                 "name": "sourceToken",
                 "type": "address"
             },
@@ -630,6 +684,84 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "ids",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "values",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "id",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
                 "name": "",
                 "type": "address"
             },
@@ -929,6 +1061,11 @@
                         "internalType": "address",
                         "name": "token",
                         "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "tokenId",
+                        "type": "uint256"
                     },
                     {
                         "internalType": "uint256",
@@ -1257,209 +1394,6 @@
             }
         ],
         "stateMutability": "payable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sourceToken",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "carbonToken",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "getRetireAmountSourceDefault",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "amountOut",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sourceToken",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "carbonToken",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "getRetireAmountSourceSpecific",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "amountOut",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sourceToken",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "carbonToken",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "redeemAmount",
-                "type": "uint256"
-            }
-        ],
-        "name": "getSourceAmountDefaultRedeem",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "amountIn",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sourceToken",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "carbonToken",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "retireAmount",
-                "type": "uint256"
-            }
-        ],
-        "name": "getSourceAmountDefaultRetirement",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "amountIn",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sourceToken",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "carbonToken",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "redeemAmounts",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "getSourceAmountSpecificRedeem",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "amountIn",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sourceToken",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "carbonToken",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "retireAmount",
-                "type": "uint256"
-            }
-        ],
-        "name": "getSourceAmountSpecificRetirement",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "amountIn",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sourceToken",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "carbonToken",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amountOut",
-                "type": "uint256"
-            }
-        ],
-        "name": "getSourceAmountSwapOnly",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "amountIn",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
         "type": "function"
     },
     {

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,7 +18,7 @@ match_test = "testSim"
 fuzz = { runs = 5_000, max_test_rejects = 1000000 }
 
 [fmt]
-int_types = "short"
+int_types = "long"
 line_length = 120
 number_underscore = "thousands"
 override_spacing = false

--- a/script/upgradeInfinity.s.sol
+++ b/script/upgradeInfinity.s.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/******************************************************************************\
-* Authors: Cujo <rawr@cujowolf.dev>
-* EIP-2535 Diamonds: https://eips.ethereum.org/EIPS/eip-2535
-
-* Script to upgrade Infinity diamond with new and revised facets
-/******************************************************************************/
+/**
+ * \
+ * Authors: Cujo <rawr@cujowolf.dev>
+ * EIP-2535 Diamonds: https://eips.ethereum.org/EIPS/eip-2535
+ * 
+ * Script to upgrade Infinity diamond with new and revised facets
+ * /*****************************************************************************
+ */
 
 import "forge-std/Script.sol";
 import "../src/infinity/interfaces/IDiamondCut.sol";
@@ -22,6 +24,8 @@ import {RetireCarbonFacet} from "../src/infinity/facets/Retire/RetireCarbonFacet
 import {RetireInfoFacet} from "../src/infinity/facets/Retire/RetireInfoFacet.sol";
 import {RetireSourceFacet} from "../src/infinity/facets/Retire/RetireSourceFacet.sol";
 import {RetirementQuoter} from "../src/infinity/facets/RetirementQuoter.sol";
+import {ERC1155ReceiverFacet} from "src/infinity/facets/ERC1155ReceiverFacet.sol";
+import {RetireICRFacet} from "src/infinity/facets/Bridges/ICR/RetireICRFacet.sol";
 import {DiamondInit} from "../src/infinity/init/DiamondInit.sol";
 import "../test/infinity/HelperContract.sol";
 
@@ -41,65 +45,27 @@ contract DeployInfinityScript is Script, HelperContract {
         RetireCarbonFacet retireCarbonF = new RetireCarbonFacet();
         RetireSourceFacet retireSourceF = new RetireSourceFacet();
         RetirementQuoter retirementQuoterF = new RetirementQuoter();
+        RetireICRFacet retireICRF = new RetireICRFacet();
+        ERC1155ReceiverFacet erc1155ReceiverF = new ERC1155ReceiverFacet();
 
         // FacetCut array which contains the three standard facets to be added
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](7);
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](2);
 
         // Klima Infinity specific facets
 
         cut[0] = (
             IDiamondCut.FacetCut({
-                facetAddress: address(c3RedeemF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RedeemC3PoolFacet")
+                facetAddress: address(retireICRF),
+                action: IDiamondCut.FacetCutAction.Add,
+                functionSelectors: generateSelectors("RetireICRFacet")
             })
         );
 
         cut[1] = (
             IDiamondCut.FacetCut({
-                facetAddress: address(c3RetireF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireC3C3TFacet")
-            })
-        );
-
-        cut[2] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(toucanRedeemF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RedeemToucanPoolFacet")
-            })
-        );
-
-        cut[3] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(toucanRetireF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireToucanTCO2Facet")
-            })
-        );
-
-        cut[4] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(retireCarbonF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireCarbonFacet")
-            })
-        );
-
-        cut[5] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(retireSourceF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetireSourceFacet")
-            })
-        );
-
-        cut[6] = (
-            IDiamondCut.FacetCut({
-                facetAddress: address(retirementQuoterF),
-                action: IDiamondCut.FacetCutAction.Replace,
-                functionSelectors: generateSelectors("RetirementQuoter")
+                facetAddress: address(erc1155ReceiverF),
+                action: IDiamondCut.FacetCutAction.Add,
+                functionSelectors: generateSelectors("ERC1155ReceiverFacet")
             })
         );
 

--- a/src/infinity/AppStorage.sol
+++ b/src/infinity/AppStorage.sol
@@ -16,17 +16,17 @@ contract Account {
         address beneficiaryAddress; // Address of the beneficiary
         string beneficiary; // Retirement beneficiary
         string retirementMessage; // Specific message going along with this retirement
-        uint amount; // Amount of carbon retired
-        uint pledgeID; // The ID of the pledge this retirement is associated with.
+        uint256 amount; // Amount of carbon retired
+        uint256 pledgeID; // The ID of the pledge this retirement is associated with.
     }
 
     struct State {
-        mapping(uint => Retirement) retirements;
-        mapping(address => uint) totalPoolRetired;
-        mapping(address => uint) totalProjectRetired;
-        uint totalRetirements;
-        uint totalCarbonRetired;
-        uint totalRewardsClaimed;
+        mapping(uint256 => Retirement) retirements;
+        mapping(address => uint256) totalPoolRetired;
+        mapping(address => uint256) totalProjectRetired;
+        uint256 totalRetirements;
+        uint256 totalCarbonRetired;
+        uint256 totalRewardsClaimed;
     }
 }
 
@@ -42,22 +42,39 @@ contract Storage {
         address[] ammRouters;
         mapping(uint8 => address[]) swapPaths;
     }
+    /**
+     * @title Token1155Settings
+     * @notice Stores the transient details of 1155 tokens received.
+     * @param tokenId      The last tokenId received from transferSingle
+     * @param value        The last value received from transferSingle
+     * @param ids          The last tokenIds received from transferBatch
+     * @param values       The last values received from transferBatch
+     */
+
+    struct Token1155Settings {
+        uint256 tokenId;
+        uint256 value;
+        uint256[] ids;
+        uint256[] values;
+    }
 }
 
 struct AppStorage {
-    mapping(uint => Storage.CarbonBridge) bridges; // Details for current carbon bridges
+    mapping(uint256 => Storage.CarbonBridge) bridges; // Details for current carbon bridges
     mapping(address => bool) isPoolToken;
     mapping(address => LibRetire.CarbonBridge) poolBridge; // Mapping of pool token address to the carbon bridge
     mapping(address => mapping(address => Storage.DefaultSwap)) swap; // Mapping of pool token to default swap behavior.
     mapping(address => Account.State) a; // Mapping of a user address to account state.
-    uint lastERC721Received; // Last ERC721 Toucan Retirement Certificate received.
-    uint fee; // Aggregator fee charged on all retirements to 3 decimals. 1000 = 1%
-    uint reentrantStatus; // An intra-transaction state variable to protect against reentrance.
+    uint256 lastERC721Received; // Last ERC721 Toucan Retirement Certificate received.
+    uint256 fee; // Aggregator fee charged on all retirements to 3 decimals. 1000 = 1%
+    uint256 reentrantStatus; // An intra-transaction state variable to protect against reentrance.
     // Internal Balances
-    mapping(address => mapping(IERC20 => uint)) internalTokenBalance; // A mapping from Klimate address to Token address to Internal Balance. It stores the amount of the Token that the Klimate has stored as an Internal Balance in Klima Infinity.
+    mapping(address => mapping(IERC20 => uint256)) internalTokenBalance; // A mapping from Klimate address to Token address to Internal Balance. It stores the amount of the Token that the Klimate has stored as an Internal Balance in Klima Infinity.
     // Meta tx items
-    mapping(address => uint) metaNonces;
+    mapping(address => uint256) metaNonces;
     bytes32 domainSeparator;
     // Swap routing
     mapping(address => mapping(address => address)) tridentPool; // Trident pool to use for getting swap info
+    // ERC1155 receipt holding
+    Storage.Token1155Settings lastERC1155Received;
 }

--- a/src/infinity/C.sol
+++ b/src/infinity/C.sol
@@ -49,6 +49,7 @@ library C {
     address private constant KLIMA_RETIREMENT_BOND = 0xa595f0d598DaF144e5a7ca91E6D9A5bAA09dDeD0;
     address constant TOUCAN_REGISTRY = 0x263fA1c180889b3a3f46330F32a4a23287E99FC9;
     address constant C3_PROJECT_FACTORY = 0xa4c951B30952f5E2feFC8a92F4d3c7551925A63B;
+    address constant ICR_PROJECT_REGISTRY = 0x9f87988FF45E9b58ae30fA1685088460125a7d8A;
 
     function toucanCert() internal pure returns (address) {
         return TOUCAN_RETIRE_CERT;
@@ -140,5 +141,9 @@ library C {
 
     function carbonmark() internal pure returns (address) {
         return CARBONMARK;
+    }
+
+    function icrProjectRegistry() internal pure returns (address) {
+        return ICR_PROJECT_REGISTRY;
     }
 }

--- a/src/infinity/facets/Bridges/ICR/RetireICRFacet.sol
+++ b/src/infinity/facets/Bridges/ICR/RetireICRFacet.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import "../../../libraries/Bridges/LibICRCarbon.sol";
+import "../../../libraries/LibRetire.sol";
+import "../../../ReentrancyGuard.sol";
+
+contract RetireICRFacet is ReentrancyGuard {
+    event CarbonRetired(
+        LibRetire.CarbonBridge carbonBridge,
+        address indexed retiringAddress,
+        string retiringEntityString,
+        address indexed beneficiaryAddress,
+        string beneficiaryString,
+        string retirementMessage,
+        address indexed carbonPool,
+        address carbonToken,
+        uint256 tokenId,
+        uint256 retiredAmount
+    );
+
+    /**
+     * @notice This contract assumes that the token being provided is a raw ICR project token.
+     *  @notice The transactions will revert otherwise.
+     */
+
+    /**
+     * @notice                     Redeems ICR credit directly
+     * @param carbonToken          Project token address
+     * @param tokenId              Token ID for project to retire
+     * @param amount               Amounts of underlying tokens to redeem
+     * @param beneficiaryAddress   0x address for the beneficiary
+     * @param beneficiaryString    String description of the beneficiary
+     * @param retirementMessage    String message for this specific retirement
+     * @param fromMode             From Mode for transfering tokens
+     * @return retirementIndex     The latest retirement index for the beneficiary address
+     */
+    function c3RetireExactC3T(
+        address carbonToken,
+        uint256 amount,
+        address beneficiaryAddress,
+        string memory beneficiaryString,
+        string memory retirementMessage,
+        LibTransfer.From fromMode
+    ) external nonReentrant returns (uint256 retirementIndex) {
+        // Currently this is a simple wrapper for direct calls on specific ICR tokens
+        // No fee is charged
+
+        LibTransfer.receiveToken(IERC20(carbonToken), amount, msg.sender, fromMode);
+
+        // Retire the carbon
+        LibC3Carbon.retireC3T(
+            address(0), // Direct retirement, no pool token
+            carbonToken,
+            amount,
+            msg.sender,
+            "KlimaDAO Retirement Aggregator",
+            beneficiaryAddress,
+            beneficiaryString,
+            retirementMessage
+        );
+
+        return LibRetire.getTotalRetirements(beneficiaryAddress);
+    }
+
+    /**
+     * @notice                     Redeems C3T directly
+     * @param carbonToken          Pool token to redeem
+     * @param amount               Amounts of underlying tokens to redeem
+     * @param retiringEntityString String description of the retiring entity
+     * @param beneficiaryAddress   0x address for the beneficiary
+     * @param beneficiaryString    String description of the beneficiary
+     * @param retirementMessage    String message for this specific retirement
+     * @param fromMode             From Mode for transfering tokens
+     * @return retirementIndex     The latest retirement index for the beneficiary address
+     */
+    function c3RetireExactC3TWithEntity(
+        address carbonToken,
+        uint256 amount,
+        string memory retiringEntityString,
+        address beneficiaryAddress,
+        string memory beneficiaryString,
+        string memory retirementMessage,
+        LibTransfer.From fromMode
+    ) external nonReentrant returns (uint256 retirementIndex) {
+        // Currently this is a simple wrapper for direct calls on specific TCO2 tokens
+        // No fee is charged
+
+        LibTransfer.receiveToken(IERC20(carbonToken), amount, msg.sender, fromMode);
+
+        // Retire the carbon
+        LibC3Carbon.retireC3T(
+            address(0), // Direct retirement, no pool token
+            carbonToken,
+            amount,
+            msg.sender,
+            retiringEntityString,
+            beneficiaryAddress,
+            beneficiaryString,
+            retirementMessage
+        );
+
+        return LibRetire.getTotalRetirements(beneficiaryAddress);
+    }
+}

--- a/src/infinity/facets/Bridges/ICR/RetireICRFacet.sol
+++ b/src/infinity/facets/Bridges/ICR/RetireICRFacet.sol
@@ -26,18 +26,21 @@ contract RetireICRFacet is ReentrancyGuard {
 
     /**
      * @notice                     Redeems ICR credit directly
-     * @param carbonToken          Project token address
+     * @param projectToken         Project token address
      * @param tokenId              Token ID for project to retire
      * @param amount               Amounts of underlying tokens to redeem
+     * @param retiringEntityString String description for the retiring entity
      * @param beneficiaryAddress   0x address for the beneficiary
      * @param beneficiaryString    String description of the beneficiary
      * @param retirementMessage    String message for this specific retirement
      * @param fromMode             From Mode for transfering tokens
      * @return retirementIndex     The latest retirement index for the beneficiary address
      */
-    function c3RetireExactC3T(
-        address carbonToken,
+    function icrRetireExactCarbon(
+        address projectToken,
+        uint256 tokenId,
         uint256 amount,
+        string memory retiringEntityString,
         address beneficiaryAddress,
         string memory beneficiaryString,
         string memory retirementMessage,
@@ -46,58 +49,23 @@ contract RetireICRFacet is ReentrancyGuard {
         // Currently this is a simple wrapper for direct calls on specific ICR tokens
         // No fee is charged
 
-        LibTransfer.receiveToken(IERC20(carbonToken), amount, msg.sender, fromMode);
+        LibTransfer.receive1155Token(IERC1155(projectToken), tokenId, amount, msg.sender, fromMode);
+
+        LibRetire.RetireDetails memory details;
+
+        details.retiringAddress = msg.sender;
+        details.retiringEntityString = retiringEntityString;
+        details.beneficiaryAddress = beneficiaryAddress;
+        details.beneficiaryString = beneficiaryString;
+        details.retirementMessage = retirementMessage;
 
         // Retire the carbon
-        LibC3Carbon.retireC3T(
+        LibICRCarbon.retireICC(
             address(0), // Direct retirement, no pool token
-            carbonToken,
+            projectToken,
+            tokenId,
             amount,
-            msg.sender,
-            "KlimaDAO Retirement Aggregator",
-            beneficiaryAddress,
-            beneficiaryString,
-            retirementMessage
-        );
-
-        return LibRetire.getTotalRetirements(beneficiaryAddress);
-    }
-
-    /**
-     * @notice                     Redeems C3T directly
-     * @param carbonToken          Pool token to redeem
-     * @param amount               Amounts of underlying tokens to redeem
-     * @param retiringEntityString String description of the retiring entity
-     * @param beneficiaryAddress   0x address for the beneficiary
-     * @param beneficiaryString    String description of the beneficiary
-     * @param retirementMessage    String message for this specific retirement
-     * @param fromMode             From Mode for transfering tokens
-     * @return retirementIndex     The latest retirement index for the beneficiary address
-     */
-    function c3RetireExactC3TWithEntity(
-        address carbonToken,
-        uint256 amount,
-        string memory retiringEntityString,
-        address beneficiaryAddress,
-        string memory beneficiaryString,
-        string memory retirementMessage,
-        LibTransfer.From fromMode
-    ) external nonReentrant returns (uint256 retirementIndex) {
-        // Currently this is a simple wrapper for direct calls on specific TCO2 tokens
-        // No fee is charged
-
-        LibTransfer.receiveToken(IERC20(carbonToken), amount, msg.sender, fromMode);
-
-        // Retire the carbon
-        LibC3Carbon.retireC3T(
-            address(0), // Direct retirement, no pool token
-            carbonToken,
-            amount,
-            msg.sender,
-            retiringEntityString,
-            beneficiaryAddress,
-            beneficiaryString,
-            retirementMessage
+            details
         );
 
         return LibRetire.getTotalRetirements(beneficiaryAddress);

--- a/src/infinity/facets/ERC1155ReceiverFacet.sol
+++ b/src/infinity/facets/ERC1155ReceiverFacet.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import "src/infinity/interfaces/IERC1155Receiver.sol";
+import {ReentrancyGuard} from "src/infinity/ReentrancyGuard.sol";
+
+contract ERC1155ReceiverFacet is ReentrancyGuard, IERC1155Receiver {
+    function onERC1155Received(address operator, address from, uint256 id, uint256 value, bytes calldata data)
+        external
+        virtual
+        override
+        returns (bytes4)
+    {
+        // Update the last tokenId received so it can be transferred.
+        s.lastERC1155Received.tokenId = id;
+        s.lastERC1155Received.value = value;
+
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) external virtual override returns (bytes4) {
+        // Update the last tokenId received so it can be transferred.
+
+        s.lastERC1155Received.ids = ids;
+        s.lastERC1155Received.values = values;
+
+        return this.onERC1155BatchReceived.selector;
+    }
+}

--- a/src/infinity/facets/Retire/RetireCarbonmarkFacet.sol
+++ b/src/infinity/facets/Retire/RetireCarbonmarkFacet.sol
@@ -53,6 +53,7 @@ contract RetireCarbonmarkFacet is ReentrancyGuard {
 
         LibRetire.retireReceivedCreditToken(
             listing.token,
+            listing.tokenId,
             retireAmount,
             msg.sender,
             retiringEntityString,

--- a/src/infinity/interfaces/ICarbonmark.sol
+++ b/src/infinity/interfaces/ICarbonmark.sol
@@ -16,6 +16,7 @@ interface ICarbonmark {
         bytes32 id;
         address account;
         address token;
+        uint256 tokenId;
         uint256 remainingAmount;
         uint256 unitPrice;
     }

--- a/src/infinity/interfaces/IERC1155Receiver.sol
+++ b/src/infinity/interfaces/IERC1155Receiver.sol
@@ -1,0 +1,46 @@
+pragma solidity ^0.8.16;
+
+interface IERC1155Receiver {
+    /**
+     * @dev Handles the receipt of a single ERC1155 token type. This function is
+     * called at the end of a `safeTransferFrom` after the balance has been updated.
+     *
+     * NOTE: To accept the transfer, this must return
+     * `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
+     * (i.e. 0xf23a6e61, or its own function selector).
+     *
+     * @param operator The address which initiated the transfer (i.e. msg.sender)
+     * @param from The address which previously owned the token
+     * @param id The ID of the token being transferred
+     * @param value The amount of tokens being transferred
+     * @param data Additional data with no specified format
+     * @return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` if transfer is allowed
+     */
+    function onERC1155Received(address operator, address from, uint256 id, uint256 value, bytes calldata data)
+        external
+        returns (bytes4);
+
+    /**
+     * @dev Handles the receipt of a multiple ERC1155 token types. This function
+     * is called at the end of a `safeBatchTransferFrom` after the balances have
+     * been updated.
+     *
+     * NOTE: To accept the transfer(s), this must return
+     * `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+     * (i.e. 0xbc197c81, or its own function selector).
+     *
+     * @param operator The address which initiated the batch transfer (i.e. msg.sender)
+     * @param from The address which previously owned the token
+     * @param ids An array containing ids of each token being transferred (order and length must match values array)
+     * @param values An array containing amounts of each token being transferred (order and length must match ids array)
+     * @param data Additional data with no specified format
+     * @return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` if transfer is allowed
+     */
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) external returns (bytes4);
+}

--- a/src/infinity/interfaces/IERC721Receiver.sol
+++ b/src/infinity/interfaces/IERC721Receiver.sol
@@ -18,7 +18,7 @@ interface IERC721Receiver {
      *
      * The selector can be obtained in Solidity with `IERC721Receiver.onERC721Received.selector`.
      */
-    function onERC721Received(address operator, address from, uint tokenId, bytes calldata data)
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data)
         external
         returns (bytes4);
 }

--- a/src/infinity/interfaces/IInternationalCarbonRegistry.sol
+++ b/src/infinity/interfaces/IInternationalCarbonRegistry.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.16;
+
+interface ICarbonContractRegistry {
+    function getTokenVaultBeaconAddress() external view returns (address);
+
+    function getVerifiedVaultAddress(uint256 id) external view returns (address);
+
+    function getSerializationAddress(string calldata serialization) external view returns (address);
+
+    function getProjectAddressFromId(uint256 projectId) external view returns (address);
+
+    function getProjectIdFromAddress(address projectAddress) external view returns (uint256);
+
+    function getBeaconAddress() external view returns (address);
+}
+
+interface IProject {
+    function retire(
+        uint256 tokenId,
+        uint256 amount,
+        address beneficiary,
+        string memory retireeName,
+        string memory customUri,
+        string memory comment,
+        bytes memory data
+    ) external returns (uint256 nftTokenId);
+}

--- a/src/infinity/libraries/Bridges/LibICRCarbon.sol
+++ b/src/infinity/libraries/Bridges/LibICRCarbon.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.16;
+
+import "../../C.sol";
+import "../LibRetire.sol";
+import "../../interfaces/IInternationalCarbonRegistry.sol";
+
+/**
+ * @author Cujo
+ * @title LibICRCarbon
+ * Handles interactions with ICR carbon credits
+ */
+
+library LibICRCarbon {
+    event CarbonRetired(
+        LibRetire.CarbonBridge carbonBridge,
+        address indexed retiringAddress,
+        string retiringEntityString,
+        address indexed beneficiaryAddress,
+        string beneficiaryString,
+        string retirementMessage,
+        address indexed carbonPool,
+        address carbonToken,
+        uint256 tokenId,
+        uint256 retiredAmount
+    );
+
+    function retireICR(
+        address poolToken,
+        address projectToken,
+        uint256 tokenId,
+        uint256 amount,
+        address retiringAddress,
+        string memory retiringEntityString,
+        address beneficiaryAddress,
+        string memory beneficiaryString,
+        string memory retirementMessage
+    ) internal returns (uint256 retiredAmount) {
+        bytes memory data;
+        IProject(projectToken).retire(
+            tokenId, amount, beneficiaryAddress, beneficiaryString, "", retirementMessage, data
+        );
+
+        LibRetire.saveRetirementDetails(
+            poolToken, projectToken, amount, beneficiaryAddress, beneficiaryString, retirementMessage
+        );
+
+        emit CarbonRetired(
+            LibRetire.CarbonBridge.ICR,
+            retiringAddress,
+            retiringEntityString,
+            beneficiaryAddress,
+            beneficiaryString,
+            retirementMessage,
+            poolToken,
+            projectToken,
+            tokenId,
+            amount
+        );
+
+        return amount;
+    }
+
+    function isValid(address token) internal view returns (bool) {
+        return ICarbonContractRegistry(C.icrProjectRegistry()).getProjectIdFromAddress(token) != 0;
+    }
+}

--- a/src/infinity/libraries/Bridges/LibICRCarbon.sol
+++ b/src/infinity/libraries/Bridges/LibICRCarbon.sol
@@ -25,33 +25,35 @@ library LibICRCarbon {
         uint256 retiredAmount
     );
 
-    function retireICR(
+    function retireICC(
         address poolToken,
         address projectToken,
         uint256 tokenId,
         uint256 amount,
-        address retiringAddress,
-        string memory retiringEntityString,
-        address beneficiaryAddress,
-        string memory beneficiaryString,
-        string memory retirementMessage
+        LibRetire.RetireDetails memory details
     ) internal returns (uint256 retiredAmount) {
         bytes memory data;
+
         IProject(projectToken).retire(
-            tokenId, amount, beneficiaryAddress, beneficiaryString, "", retirementMessage, data
+            tokenId, amount, details.beneficiaryAddress, details.beneficiaryString, "", details.retirementMessage, data
         );
 
         LibRetire.saveRetirementDetails(
-            poolToken, projectToken, amount, beneficiaryAddress, beneficiaryString, retirementMessage
+            poolToken,
+            projectToken,
+            amount,
+            details.beneficiaryAddress,
+            details.beneficiaryString,
+            details.retirementMessage
         );
 
         emit CarbonRetired(
             LibRetire.CarbonBridge.ICR,
-            retiringAddress,
-            retiringEntityString,
-            beneficiaryAddress,
-            beneficiaryString,
-            retirementMessage,
+            details.retiringAddress,
+            details.retiringEntityString,
+            details.beneficiaryAddress,
+            details.beneficiaryString,
+            details.retirementMessage,
             poolToken,
             projectToken,
             tokenId,

--- a/src/infinity/libraries/LibRetire.sol
+++ b/src/infinity/libraries/LibRetire.sol
@@ -25,7 +25,8 @@ library LibRetire {
     enum CarbonBridge {
         TOUCAN,
         MOSS,
-        C3
+        C3,
+        ICR
     }
 
     /* ========== Default Redemption Retirements ========== */
@@ -41,7 +42,7 @@ library LibRetire {
      */
     function retireReceivedCarbon(
         address poolToken,
-        uint amount,
+        uint256 amount,
         address retiringAddress,
         string memory retiringEntityString,
         address beneficiaryAddress,
@@ -98,13 +99,13 @@ library LibRetire {
     function retireReceivedExactCarbonSpecific(
         address poolToken,
         address projectToken,
-        uint amount,
+        uint256 amount,
         address retiringAddress,
         string memory retiringEntityString,
         address beneficiaryAddress,
         string memory beneficiaryString,
         string memory retirementMessage
-    ) internal returns (uint redeemedAmount) {
+    ) internal returns (uint256 redeemedAmount) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         require(
             s.poolBridge[poolToken] == CarbonBridge.TOUCAN || s.poolBridge[poolToken] == CarbonBridge.C3,
@@ -200,13 +201,13 @@ library LibRetire {
     function retireReceivedCarbonSpecificFromSource(
         address poolToken,
         address projectToken,
-        uint amount,
+        uint256 amount,
         address retiringAddress,
         string memory retiringEntityString,
         address beneficiaryAddress,
         string memory beneficiaryString,
         string memory retirementMessage
-    ) internal returns (uint redeemedAmount) {
+    ) internal returns (uint256 redeemedAmount) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         require(
             s.poolBridge[poolToken] == CarbonBridge.TOUCAN || s.poolBridge[poolToken] == CarbonBridge.C3,
@@ -250,7 +251,7 @@ library LibRetire {
      * @param retireAmount      Pool token used to retire
      * @return totalCarbon      Total pool token needed
      */
-    function getTotalCarbon(uint retireAmount) internal view returns (uint totalCarbon) {
+    function getTotalCarbon(uint256 retireAmount) internal view returns (uint256 totalCarbon) {
         return retireAmount + getFee(retireAmount);
     }
 
@@ -260,7 +261,11 @@ library LibRetire {
      * @param retireAmount      Amount of carbon wanting to retire
      * @return totalCarbon      Total pool token needed
      */
-    function getTotalCarbonSpecific(address poolToken, uint retireAmount) internal view returns (uint totalCarbon) {
+    function getTotalCarbonSpecific(address poolToken, uint256 retireAmount)
+        internal
+        view
+        returns (uint256 totalCarbon)
+    {
         // This is for exact carbon retirements
         AppStorage storage s = LibAppStorage.diamondStorage();
 
@@ -278,7 +283,7 @@ library LibRetire {
      * @param carbonAmount      Amount being retired
      * @return fee              Total fee charged
      */
-    function getFee(uint carbonAmount) internal view returns (uint fee) {
+    function getFee(uint256 carbonAmount) internal view returns (uint256 fee) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         fee = (carbonAmount * s.fee) / 100_000;
     }
@@ -295,14 +300,14 @@ library LibRetire {
     function saveRetirementDetails(
         address poolToken,
         address projectToken,
-        uint amount,
+        uint256 amount,
         address beneficiaryAddress,
         string memory beneficiaryString,
         string memory retirementMessage
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        (uint currentRetirementIndex,,) =
+        (uint256 currentRetirementIndex,,) =
             IKlimaCarbonRetirements(C.klimaCarbonRetirements()).getRetirementTotals(beneficiaryAddress);
 
         // Save the base details of the retirement
@@ -317,28 +322,28 @@ library LibRetire {
 
     /* ========== Account Getters ========== */
 
-    function getTotalRetirements(address account) internal view returns (uint totalRetirements) {
+    function getTotalRetirements(address account) internal view returns (uint256 totalRetirements) {
         (totalRetirements,,) = IKlimaCarbonRetirements(C.klimaCarbonRetirements()).getRetirementTotals(account);
     }
 
-    function getTotalCarbonRetired(address account) internal view returns (uint totalCarbonRetired) {
+    function getTotalCarbonRetired(address account) internal view returns (uint256 totalCarbonRetired) {
         (, totalCarbonRetired,) = IKlimaCarbonRetirements(C.klimaCarbonRetirements()).getRetirementTotals(account);
     }
 
-    function getTotalPoolRetired(address account, address poolToken) internal view returns (uint totalPoolRetired) {
+    function getTotalPoolRetired(address account, address poolToken) internal view returns (uint256 totalPoolRetired) {
         return IKlimaCarbonRetirements(C.klimaCarbonRetirements()).getRetirementPoolInfo(account, poolToken);
     }
 
-    function getTotalProjectRetired(address account, address projectToken) internal view returns (uint) {
+    function getTotalProjectRetired(address account, address projectToken) internal view returns (uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return s.a[account].totalProjectRetired[projectToken];
     }
 
-    function getTotalRewardsClaimed(address account) internal view returns (uint totalClaimed) {
+    function getTotalRewardsClaimed(address account) internal view returns (uint256 totalClaimed) {
         (,, totalClaimed) = IKlimaCarbonRetirements(C.klimaCarbonRetirements()).getRetirementTotals(account);
     }
 
-    function getRetirementDetails(address account, uint retirementIndex)
+    function getRetirementDetails(address account, uint256 retirementIndex)
         internal
         view
         returns (
@@ -347,7 +352,7 @@ library LibRetire {
             address beneficiaryAddress,
             string memory beneficiary,
             string memory retirementMessage,
-            uint amount
+            uint256 amount
         )
     {
         (poolTokenAddress, amount, beneficiary, retirementMessage) =

--- a/src/infinity/libraries/LibRetire.sol
+++ b/src/infinity/libraries/LibRetire.sol
@@ -12,6 +12,7 @@ import {LibMeta} from "./LibMeta.sol";
 import "./Bridges/LibToucanCarbon.sol";
 import "./Bridges/LibMossCarbon.sol";
 import "./Bridges/LibC3Carbon.sol";
+import "./Bridges/LibICRCarbon.sol";
 import "./Token/LibTransfer.sol";
 import "./TokenSwap/LibSwap.sol";
 import "../interfaces/IKlimaInfinity.sol";
@@ -27,6 +28,14 @@ library LibRetire {
         MOSS,
         C3,
         ICR
+    }
+
+    struct RetireDetails {
+        address retiringAddress;
+        string retiringEntityString;
+        address beneficiaryAddress;
+        string beneficiaryString;
+        string retirementMessage;
     }
 
     /* ========== Default Redemption Retirements ========== */
@@ -155,6 +164,7 @@ library LibRetire {
      */
     function retireReceivedCreditToken(
         address creditToken,
+        uint256 tokenId,
         uint256 amount,
         address retiringAddress,
         string memory retiringEntityString,
@@ -183,6 +193,23 @@ library LibRetire {
                 beneficiaryAddress,
                 beneficiaryString,
                 retirementMessage
+            );
+        } else if (LibICRCarbon.isValid(creditToken)) {
+            RetireDetails memory details;
+
+            details.retiringAddress = retiringAddress;
+            details.retiringEntityString = retiringEntityString;
+            details.beneficiaryAddress = beneficiaryAddress;
+            details.beneficiaryString = beneficiaryString;
+            details.retirementMessage = retirementMessage;
+
+            // Retire the carbon
+            LibICRCarbon.retireICC(
+                address(0), // Direct retirement, no pool token
+                creditToken,
+                tokenId,
+                amount,
+                details
             );
         }
     }

--- a/src/infinity/libraries/Token/LibTransfer.sol
+++ b/src/infinity/libraries/Token/LibTransfer.sol
@@ -9,6 +9,7 @@
 pragma solidity ^0.8.16;
 
 import "oz/token/ERC20/utils/SafeERC20.sol";
+import "oz/token/ERC1155/IERC1155.sol";
 import "./LibBalance.sol";
 
 library LibTransfer {
@@ -25,12 +26,12 @@ library LibTransfer {
         INTERNAL
     }
 
-    function transferToken(IERC20 token, address recipient, uint amount, From fromMode, To toMode)
+    function transferToken(IERC20 token, address recipient, uint256 amount, From fromMode, To toMode)
         internal
-        returns (uint transferredAmount)
+        returns (uint256 transferredAmount)
     {
         if (fromMode == From.EXTERNAL && toMode == To.EXTERNAL) {
-            uint beforeBalance = token.balanceOf(recipient);
+            uint256 beforeBalance = token.balanceOf(recipient);
             token.safeTransferFrom(msg.sender, recipient, amount);
             return token.balanceOf(recipient) - beforeBalance;
         }
@@ -39,21 +40,33 @@ library LibTransfer {
         return amount;
     }
 
-    function receiveToken(IERC20 token, uint amount, address sender, From mode)
+    function receiveToken(IERC20 token, uint256 amount, address sender, From mode)
         internal
-        returns (uint receivedAmount)
+        returns (uint256 receivedAmount)
     {
         if (amount == 0) return 0;
         if (mode != From.EXTERNAL) {
             receivedAmount = LibBalance.decreaseInternalBalance(sender, token, amount, mode != From.INTERNAL);
             if (amount == receivedAmount || mode == From.INTERNAL_TOLERANT) return receivedAmount;
         }
-        uint beforeBalance = token.balanceOf(address(this));
+        uint256 beforeBalance = token.balanceOf(address(this));
         token.safeTransferFrom(sender, address(this), amount - receivedAmount);
         return receivedAmount + (token.balanceOf(address(this)) - beforeBalance);
     }
 
-    function sendToken(IERC20 token, uint amount, address recipient, To mode) internal {
+    function receive1155Token(IERC1155 token, uint256 tokenId, uint256 amount, address sender, From mode)
+        internal
+        returns (uint256 receivedAmount)
+    {
+        if (amount == 0) return 0;
+        require(mode == From.EXTERNAL, "Only external transfers allowed");
+
+        uint256 beforeBalance = token.balanceOf(address(this), tokenId);
+        token.safeTransferFrom(sender, address(this), tokenId, amount, "");
+        return (token.balanceOf(address(this), tokenId) - beforeBalance);
+    }
+
+    function sendToken(IERC20 token, uint256 amount, address recipient, To mode) internal {
         if (amount == 0) return;
         if (mode == To.INTERNAL) LibBalance.increaseInternalBalance(recipient, token, amount);
         else token.safeTransfer(recipient, amount);

--- a/test/infinity/Bridge/ICR.RetireICC.t.sol
+++ b/test/infinity/Bridge/ICR.RetireICC.t.sol
@@ -1,0 +1,110 @@
+pragma solidity ^0.8.16;
+
+import "../HelperContract.sol";
+import {RetireICRFacet} from "../../../src/infinity/facets/Bridges/ICR/RetireICRFacet.sol";
+import {RetirementQuoter} from "../../../src/infinity/facets/RetirementQuoter.sol";
+import {LibRetire} from "../../../src/infinity/libraries/LibRetire.sol";
+import {LibTransfer} from "../../../src/infinity/libraries/Token/LibTransfer.sol";
+import {IERC1155} from "oz/token/ERC1155/IERC1155.sol";
+
+import {console2} from "../../../lib/forge-std/src/console2.sol";
+
+import "../TestHelper.sol";
+import "../../helpers/AssertionHelper.sol";
+
+contract RetireICRICCFacetTest is TestHelper, AssertionHelper {
+    event CarbonRetired(
+        LibRetire.CarbonBridge carbonBridge,
+        address indexed retiringAddress,
+        string retiringEntityString,
+        address indexed beneficiaryAddress,
+        string beneficiaryString,
+        string retirementMessage,
+        address indexed carbonPool,
+        address carbonToken,
+        uint256 tokenId,
+        uint256 retiredAmount
+    );
+
+    RetireICRFacet retireICRFacet;
+    RetirementQuoter quoterFacet;
+    ConstantsGetter constantsFacet;
+
+    uint256 defaultCarbonRetireAmount = 5 * 1e18;
+    string beneficiary = "Test Beneficiary";
+    string message = "Test Message";
+    string entity = "Test Entity";
+
+    address diamond = vm.envAddress("INFINITY_ADDRESS");
+    address beneficiaryAddress = vm.envAddress("BENEFICIARY_ADDRESS");
+
+    address ICC = 0xaE63fBD056512fC4B1D15B58A98F9Aaea44b18a9;
+
+    function setUp() public {
+        addConstantsGetter(diamond);
+        constantsFacet = ConstantsGetter(diamond);
+        retireICRFacet = RetireICRFacet(diamond);
+        quoterFacet = RetirementQuoter(diamond);
+
+        upgradeCurrentDiamond(diamond);
+    }
+
+    function onERC1155Received(address operator, address from, uint256 id, uint256 value, bytes calldata data)
+        external
+        returns (bytes4)
+    {
+        return this.onERC1155Received.selector;
+    }
+
+    function test_infinity_icrRetireExactICC() public {
+        uint256 tokenId = 48;
+        uint256 retireAmount = 100e18;
+        mintERC1155Tokens(ICC, tokenId, retireAmount, address(this));
+
+        // swipeERC20Tokens(DEFAULT_PROJECT, defaultCarbonRetireAmount, UBO, address(this));
+
+        IERC1155(ICC).setApprovalForAll(diamond, true);
+
+        uint256 currentRetirements = LibRetire.getTotalRetirements(beneficiaryAddress);
+        uint256 currentTotalCarbon = LibRetire.getTotalCarbonRetired(beneficiaryAddress);
+
+        uint256 expectedRetirements = currentRetirements + 1;
+        uint256 expectedCarbonRetired = currentTotalCarbon + defaultCarbonRetireAmount;
+
+        // Set up expectEmit
+        vm.expectEmit(true, true, true, true);
+
+        // Emit expected CarbonRetired event
+        emit CarbonRetired(
+            LibRetire.CarbonBridge.ICR,
+            address(this),
+            entity,
+            beneficiaryAddress,
+            beneficiary,
+            message,
+            address(0),
+            ICC,
+            tokenId,
+            defaultCarbonRetireAmount
+        );
+
+        uint256 retirementIndex = retireICRFacet.icrRetireExactCarbon(
+            ICC,
+            tokenId,
+            defaultCarbonRetireAmount,
+            entity,
+            beneficiaryAddress,
+            beneficiary,
+            message,
+            LibTransfer.From.EXTERNAL
+        );
+
+        // No tokens left in contract
+        // assertZeroTokenBalance(carbonToken, diamond);
+
+        // Account state values updated
+        assertEq(LibRetire.getTotalRetirements(beneficiaryAddress), expectedRetirements);
+        assertEq(retirementIndex, expectedRetirements);
+        assertEq(LibRetire.getTotalCarbonRetired(beneficiaryAddress), expectedCarbonRetired);
+    }
+}

--- a/test/infinity/Retire/RetireCarbonmarkListing.t.sol
+++ b/test/infinity/Retire/RetireCarbonmarkListing.t.sol
@@ -76,7 +76,7 @@ contract RetireCarbonmarkListing is TestHelper, AssertionHelper {
             ICarbonmark(CARBONMARK).createListing(TCO2, listingAmount, 5_000_000, 1e17, block.timestamp + 3600);
 
         ICarbonmark.CreditListing memory listing =
-            ICarbonmark.CreditListing(listingId, address(this), TCO2, listingAmount, 5_000_000);
+            ICarbonmark.CreditListing(listingId, address(this), TCO2, 0, listingAmount, 5_000_000);
 
         retireExactBCT(listing, 5e17);
     }

--- a/test/infinity/interfaces/ICR.sol
+++ b/test/infinity/interfaces/ICR.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.16;
+
+interface ICRProject {
+    function verifyAndMintExPost(
+        address verificationVault,
+        uint256 tokenId,
+        uint256 amountVerified,
+        uint256 amountToAnteHolders,
+        uint256 verificationPeriodStart,
+        uint256 verificationPeriodEnd,
+        string memory monitoringReport
+    ) external;
+
+    function owner() external returns (address owner);
+}


### PR DESCRIPTION
Add both an ICR retirement wrapper facet, along with an updated Carbonmark retirement facet to support the possibility of purchasing an 1155 token with a tokenId.