### PR TITLE
docs: changed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ These examples use a localhost fork running on the `anvil` command
 
 ### Infinity Diamond Deployment
 
-- Deploy the base Diamond, facet implementations, and perform the diamon cut with the following script.
+- Deploy the base Diamond, facet implementations, and perform the diamond cut with the following script.
   ```
   forge script script/deployInfinity.s.sol:DeployInfinityScript --fork-url http://localhost:8545 --broadcast --ffi
   ```
 
 ## Deprecated Contracts
 
-Note that the `AlphaKlimaRedeemUpgradeable` will fail to get built by default, and therefore has been marked deprecated.
+Note that the `AlphaKlimaRedeemUpgradeable` will fail to build by default, and therefore has been marked deprecated.
 
 In order to compile this contract, you will need to manually update the `@openzeppelin/contracts-upgradeable`
 contracts that are downloaded in your `node_modules` by changing `_trustedForwarder`
@@ -59,20 +59,20 @@ in `metatx/ERC2771ContextUpgradeable.sol` from a private to a public address.
 
 There is another issue related to the `_trustedForwarder` in that contract that has not yet been resolved.
 
-Since `aKLIMA` was a prelaunch coupon and the existing deployed versino of the redemption contract works as expected, this contract is no longer needed.
+Since `aKLIMA` was a prelaunch coupon and the existing deployed version of the redemption contract works as expected, this contract is no longer needed.
 
 ## Documentation
 
 This repo is configured with [Foundry](https://book.getfoundry.sh/) to generate documentation for the solidity source files with the [forge doc](https://book.getfoundry.sh/reference/forge/forge-doc) command.
 
-Foundry forge doc generates and builds an mdbook from the natspec comments contained within the Solidity source files.The `book.toml` file located in the root folder contains the config settings and the `preprocess_summary.py` script allows you to customize the book after it is generated.
+Foundry `forge doc` generates and builds an mdbook from the natspec comments contained within the Solidity source files.The `book.toml` file located in the root folder contains the config settings and the `preprocess_summary.py` script allows you to customize the book after it is generated.
 
 The `preprocess_summary.py` script is necessary to customize the book *after Foundry has generated the book from the natspec comments.* This script can also be used to insert additional pages into the book automatically. *If you were to modify the book without this script, each time someone ran the build command it will overwrite these changes.*
 
 *If you have not installed Foundry, follow the guide above before proceeding.*
 
 **Please follow these rules:**
-- Annonate your code with [proper NatSpec comments](https://docs.soliditylang.org/en/latest/natspec-format.html)
+- Annotate your code with [proper NatSpec comments](https://docs.soliditylang.org/en/latest/natspec-format.html)
 - Before committing code, run the `forge doc --build` in order to build the doc/book
 - A new mdbook should be manually deployed to the public documentation from the `main` branch each time contracts are verified to block explorers like Polygonscan.
 


### PR DESCRIPTION
I changed a few typos in the README.md and the wording of a few sentences
* diamon -> diamond
* get built -> build
* versino -> version
* forge doc -> `forge doc`
* Annonate -> Annotate