### PR TITLE
Blacklist RA v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:batch-call": "forge test --fork-url http://localhost:8545 -vvvv --ffi --match-contract ^BatchCallTest$ --summary",
     "test:upgrade-tver": "forge test --fork-url http://localhost:8545 -vvvv --ffi --match-contract UpgradeInfinityForTVERCredits --summary",
     "test:upgrade-bct-swap-paths": "forge test --fork-url http://localhost:8545 -vvv --ffi --match-contract UpgradeBCTSwapPaths --summary",
+    "test:blacklist-v1": "forge test --fork-url http://localhost:8545 -vvvv --ffi --match-contract RetireBlacklistV1Test --summary",
     "deploy:upgrade-bct-swap-paths": "forge script script/11_upgradeBCTSwapPaths.s.sol --rpc-url $POLYGON_URL --chain 137 --broadcast --verify --ffi -vvvv",
     "propose:01_update_swap_routes": "bun multisig-proposals/01-update-swap-routes.ts",
     "propose:02_update_retiremark_facet": "bun multisig-proposals/02-update-retirecarbonmark-facet.ts",

--- a/script/12_upgradeInfinityForV1Blacklist.s.sol
+++ b/script/12_upgradeInfinityForV1Blacklist.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Script.sol";
+import "../src/infinity/interfaces/IDiamondCut.sol";
+import {RetireCarbonFacet} from "../src/infinity/facets/Retire/RetireCarbonFacet.sol";
+import {RetireSourceFacet} from "../src/infinity/facets/Retire/RetireSourceFacet.sol";
+import {console2} from "forge-std/console2.sol";
+import "../test/infinity/HelperContract.sol";
+
+
+contract UpgradeInfinityForV1BlacklistScript is Script, HelperContract {
+    RetireCarbonFacet public retireCarbonF;
+    RetireSourceFacet public retireSourceF;
+
+    bytes public updateFacetsCalldata;
+
+    function run() external returns (bytes memory facetsCalldata) {
+        // Primary: keystore
+        uint256 fallbackPrivateKey = vm.envOr("PRIVATE_KEY", uint256(0));
+
+        if (fallbackPrivateKey == 0) {
+            vm.startBroadcast();
+        } else {
+            vm.startBroadcast(fallbackPrivateKey);
+        }
+
+        // Deploy updated facets
+        retireCarbonF = new RetireCarbonFacet();
+        retireSourceF = new RetireSourceFacet();
+
+        vm.stopBroadcast();
+
+        IDiamondCut.FacetCut[] memory facetCuts = new IDiamondCut.FacetCut[](2);
+        facetCuts[0] = (
+            IDiamondCut.FacetCut({
+                facetAddress: address(retireCarbonF),
+                action: IDiamondCut.FacetCutAction.Replace,
+                functionSelectors: generateSelectors("RetireCarbonFacet")
+            })
+        );
+        facetCuts[1] = (
+            IDiamondCut.FacetCut({
+                facetAddress: address(retireSourceF),
+                action: IDiamondCut.FacetCutAction.Replace,
+                functionSelectors: generateSelectors("RetireSourceFacet")
+            })
+        );
+
+        // No storage init needed 
+        updateFacetsCalldata =
+            abi.encodeWithSelector(IDiamondCut.diamondCut.selector, facetCuts, address(0), "");
+
+        console2.log("New RetireCarbonFacet Address:");
+        console2.logAddress(address(retireCarbonF));
+        console2.log("\nNew RetireSourceFacet Address:");
+        console2.logAddress(address(retireSourceF));
+        console2.log("\nFacet Update Calldata (execute via diamond owner):");
+        console2.logBytes(updateFacetsCalldata);
+
+        return updateFacetsCalldata;
+    }
+}

--- a/src/infinity/C.sol
+++ b/src/infinity/C.sol
@@ -64,6 +64,8 @@ library C {
     address constant COOREST_POCC_TOKEN = 0x51cF819352FC536aD8A84214922615C160BB497D;
     address constant COOREST_CCO2_TOKEN = 0x82B37070e43C1BA0EA9e2283285b674eF7f1D4E2;
 
+    address constant RETIREMENT_V1_AGGREGATOR = 0xEde3bd57a04960E6469B70B4863cE1c9d9363Cb8;
+
     function toucanCert() internal pure returns (address) {
         return TOUCAN_RETIRE_CERT;
     }
@@ -194,5 +196,9 @@ library C {
 
     function coorestCCO2Token() internal pure returns (address) {
         return COOREST_CCO2_TOKEN;
+    }
+
+    function retirementV1Aggregator() internal pure returns (address) {
+        return RETIREMENT_V1_AGGREGATOR;
     }
 }

--- a/src/infinity/facets/Retire/RetireCarbonFacet.sol
+++ b/src/infinity/facets/Retire/RetireCarbonFacet.sol
@@ -47,6 +47,8 @@ contract RetireCarbonFacet is ReentrancyGuard {
         string memory retirementMessage,
         LibTransfer.From fromMode
     ) external payable nonReentrant returns (uint256 retirementIndex) {
+        LibRetire.enforceNotBlacklisted(msg.sender);
+
         require(retireAmount > 0, "Cannot retire zero tonnes");
 
         uint256 totalCarbon = LibRetire.getTotalCarbon(retireAmount);
@@ -127,6 +129,8 @@ contract RetireCarbonFacet is ReentrancyGuard {
         string memory retirementMessage,
         LibTransfer.From fromMode
     ) external payable nonReentrant returns (uint256 retirementIndex) {
+        LibRetire.enforceNotBlacklisted(msg.sender);
+        
         require(retireAmount > 0, "Cannot retire zero tonnes");
 
         uint256 totalCarbon = LibRetire.getTotalCarbonSpecific(poolToken, retireAmount);

--- a/src/infinity/facets/Retire/RetireSourceFacet.sol
+++ b/src/infinity/facets/Retire/RetireSourceFacet.sol
@@ -42,6 +42,8 @@ contract RetireSourceFacet is ReentrancyGuard {
         string memory retirementMessage,
         LibTransfer.From fromMode
     ) external payable nonReentrant returns (uint256 retirementIndex) {
+        LibRetire.enforceNotBlacklisted(msg.sender);
+        
         require(maxAmountIn > 0, "Cannot retire zero tonnes");
 
         LibTransfer.receiveToken(IERC20(sourceToken), maxAmountIn, msg.sender, fromMode);
@@ -106,6 +108,8 @@ contract RetireSourceFacet is ReentrancyGuard {
         string memory retirementMessage,
         LibTransfer.From fromMode
     ) external payable nonReentrant returns (uint256 retirementIndex) {
+        LibRetire.enforceNotBlacklisted(msg.sender);
+        
         require(maxAmountIn > 0, "Cannot retire zero tonnes");
 
         LibTransfer.receiveToken(IERC20(sourceToken), maxAmountIn, msg.sender, fromMode);

--- a/src/infinity/libraries/LibRetire.sol
+++ b/src/infinity/libraries/LibRetire.sol
@@ -477,4 +477,16 @@ library LibRetire {
         AppStorage storage s = LibAppStorage.diamondStorage();
         projectTokenAddress = s.a[account].retirements[retirementIndex].projectTokenAddress;
     }
+
+    // Simple fix; given polygon deprecation
+    function isBlacklisted(address account) internal view returns (bool) {
+        if (account == C.retirementV1Aggregator()) {
+            return true;
+        }
+        return false;
+    }
+
+    function enforceNotBlacklisted(address account) internal view {
+        require(!isBlacklisted(account), "Caller is blacklisted");
+    }
 }

--- a/test/infinity/Retire/RetireBlacklistV1.t.sol
+++ b/test/infinity/Retire/RetireBlacklistV1.t.sol
@@ -1,0 +1,141 @@
+pragma solidity ^0.8.16;
+
+import {RetireCarbonFacet} from "../../../src/infinity/facets/Retire/RetireCarbonFacet.sol";
+import {RetireSourceFacet} from "../../../src/infinity/facets/Retire/RetireSourceFacet.sol";
+import {LibRetire} from "../../../src/infinity/libraries/LibRetire.sol";
+import {LibTransfer} from "../../../src/infinity/libraries/Token/LibTransfer.sol";
+import {C} from "../../../src/infinity/C.sol";
+
+import "../TestHelper.sol";
+import "../../helpers/AssertionHelper.sol";
+
+
+contract RetireBlacklistV1Test is TestHelper, AssertionHelper {
+    RetireCarbonFacet retireCarbonFacet;
+    RetireSourceFacet retireSourceFacet;
+    ConstantsGetter constantsFacet;
+
+    string constant BLACKLIST_REVERT = "Caller is blacklisted";
+    string constant ZERO_REVERT = "Cannot retire zero tonnes";
+
+    // Retirement details
+    string entity = "Test Entity";
+    string beneficiary = "Test Beneficiary";
+    string message = "Test Message";
+    address beneficiaryAddress = vm.envAddress("BENEFICIARY_ADDRESS");
+    address diamond = vm.envAddress("INFINITY_ADDRESS");
+
+    // The deprecated v1 aggregator that must be blocked
+    address V1_AGGREGATOR = C.retirementV1Aggregator();
+
+    address BCT;
+    address DEFAULT_PROJECT_BCT;
+
+    function setUp() public {
+        addConstantsGetter(diamond);
+        upgradeCurrentDiamond(diamond); // replaces RetireCarbonFacet (carries the modifier)
+        replaceRetireSourceFacet(diamond); // replaces RetireSourceFacet (carries the modifier)
+
+        retireCarbonFacet = RetireCarbonFacet(diamond);
+        retireSourceFacet = RetireSourceFacet(diamond);
+        constantsFacet = ConstantsGetter(diamond);
+
+        BCT = constantsFacet.bct();
+        DEFAULT_PROJECT_BCT = getDefaultToucanProject(BCT);
+    }
+
+    /// @dev The v1 aggregator constant should match the deprecated aggregator address.
+    function test_infinity_blacklist_v1AggregatorAddress() public {
+        assertEq(V1_AGGREGATOR, 0xEde3bd57a04960E6469B70B4863cE1c9d9363Cb8);
+    }
+
+    /* ========== v1 calls must revert ========== */
+
+    function test_infinity_blacklist_retireExactCarbonDefault_reverts() public {
+        vm.prank(V1_AGGREGATOR);
+        vm.expectRevert(bytes(BLACKLIST_REVERT));
+        retireCarbonFacet.retireExactCarbonDefault(
+            BCT, BCT, 1e18, 1e18, entity, beneficiaryAddress, beneficiary, message, LibTransfer.From.EXTERNAL
+        );
+    }
+
+    function test_infinity_blacklist_retireExactCarbonSpecific_reverts() public {
+        vm.prank(V1_AGGREGATOR);
+        vm.expectRevert(bytes(BLACKLIST_REVERT));
+        retireCarbonFacet.retireExactCarbonSpecific(
+            BCT,
+            BCT,
+            DEFAULT_PROJECT_BCT,
+            1e18,
+            1e18,
+            entity,
+            beneficiaryAddress,
+            beneficiary,
+            message,
+            LibTransfer.From.EXTERNAL
+        );
+    }
+
+    function test_infinity_blacklist_retireExactSourceDefault_reverts() public {
+        vm.prank(V1_AGGREGATOR);
+        vm.expectRevert(bytes(BLACKLIST_REVERT));
+        retireSourceFacet.retireExactSourceDefault(
+            BCT, BCT, 1e18, entity, beneficiaryAddress, beneficiary, message, LibTransfer.From.EXTERNAL
+        );
+    }
+
+    function test_infinity_blacklist_retireExactSourceSpecific_reverts() public {
+        vm.prank(V1_AGGREGATOR);
+        vm.expectRevert(bytes(BLACKLIST_REVERT));
+        retireSourceFacet.retireExactSourceSpecific(
+            BCT,
+            BCT,
+            DEFAULT_PROJECT_BCT,
+            1e18,
+            entity,
+            beneficiaryAddress,
+            beneficiary,
+            message,
+            LibTransfer.From.EXTERNAL
+        );
+    }
+
+    /* ========== Non-v1 callers still pass the modifier ========== */
+    // A non-blacklisted caller sailing past the modifier hits the zero-amount guard
+    // in the function body instead, proving the modifier does not block normal callers.
+
+    function test_infinity_blacklist_allowsNonV1_retireExactCarbonDefault() public {
+        vm.prank(makeAddr("normalUser"));
+        vm.expectRevert(bytes(ZERO_REVERT));
+        retireCarbonFacet.retireExactCarbonDefault(
+            BCT, BCT, 0, 0, entity, beneficiaryAddress, beneficiary, message, LibTransfer.From.EXTERNAL
+        );
+    }
+
+    function test_infinity_blacklist_allowsNonV1_retireExactSourceDefault() public {
+        vm.prank(makeAddr("normalUser"));
+        vm.expectRevert(bytes(ZERO_REVERT));
+        retireSourceFacet.retireExactSourceDefault(
+            BCT, BCT, 0, entity, beneficiaryAddress, beneficiary, message, LibTransfer.From.EXTERNAL
+        );
+    }
+
+    /* ========== Facet upgrade helper ========== */
+
+    function replaceRetireSourceFacet(address infinityDiamond) internal {
+        OwnershipFacet ownership = OwnershipFacet(infinityDiamond);
+        vm.startPrank(ownership.owner());
+
+        RetireSourceFacet newSourceFacet = new RetireSourceFacet();
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(newSourceFacet),
+            action: IDiamondCut.FacetCutAction.Replace,
+            functionSelectors: generateSelectors("RetireSourceFacet")
+        });
+
+        IDiamondCut(infinityDiamond).diamondCut(cut, address(0), "");
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
### What
  Blocks the deprecated v1 RA from retiring through the diamond.

### Coverage
  v1 routes through the four entrypoints, all now guarded by `LibRetire.enforceNotBlacklisted`:
  - `retireExactCarbonDefault` / `retireExactCarbonSpecific` 
  (RetireCarbonFacet)
  - `retireExactSourceDefault` / `retireExactSourceSpecific` 
  (RetireSourceFacet)

### C vs. AppStorage
  The blacklist is a hardcoded `constant` in `C.sol`; no storage layout risk. More straightforward given imminent deprecation

### Tests
  7 passing